### PR TITLE
Unknown events have no handlers

### DIFF
--- a/lib/shipit/webhooks.rb
+++ b/lib/shipit/webhooks.rb
@@ -26,7 +26,7 @@ module Shipit
     end
 
     def self.for_event(event)
-      handlers[event]
+      handlers.fetch(event) { [] }
     end
   end
 end

--- a/test/lib/shipit/wehbooks/handlers_test.rb
+++ b/test/lib/shipit/wehbooks/handlers_test.rb
@@ -13,6 +13,14 @@ module Shipit
 
         Shipit::Webhooks.reset_handler_registry
       end
+
+      test "unknown events have no handlers" do
+        event = '_'
+
+        handlers = Shipit::Webhooks.for_event(event)
+
+        assert_equal [], handlers
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes:

```
undefined method `each' for nil:NilClass
``` 

when receiving events for which there are no handlers registered: https://sentry.io/organizations/power-home-remodeling-group/issues/1403166986/?project=1833592&query=is%3Aunresolved