### PR TITLE
Add ability to configure per-pull-request provisioning behavior

### DIFF
--- a/app/controllers/shipit/repositories_controller.rb
+++ b/app/controllers/shipit/repositories_controller.rb
@@ -52,6 +52,8 @@ module Shipit
     def update_params
       params.require(:repository).permit(
         :provision_pr_stacks,
+        :provisioning_behavior,
+        :provisioning_label_name,
       )
     end
 

--- a/app/models/shipit/repository.rb
+++ b/app/models/shipit/repository.rb
@@ -14,6 +14,15 @@ module Shipit
 
     has_many :stacks, dependent: :destroy
 
+    enum(
+      provisioning_behavior: {
+        allow_all: 0,
+        allow_with_label: 1,
+        prevent_with_label: 2,
+      },
+      _prefix: :provisioning_behavior,
+    )
+
     def self.from_github_repo_name(github_repo_name)
       repo_owner, repo_name = github_repo_name.downcase.split('/')
       find_by(owner: repo_owner, name: repo_name)

--- a/app/views/shipit/repositories/settings.html.erb
+++ b/app/views/shipit/repositories/settings.html.erb
@@ -8,10 +8,28 @@
 
     <div class="setting-section">
       <%= form_for @repository do |f| %>
-        <div class="field-wrapper">
-          <%= f.check_box :provision_pr_stacks %>
-          <%= f.label :provision_pr_stacks, "Dynamically provision stacks for Pull Requests?" %>
-        </div>
+        <fieldset class="form-group">
+          <div class="field-wrapper">
+            <%= f.check_box :provision_pr_stacks %>
+            <%= f.label :provision_pr_stacks, "Dynamically provision stacks for Pull Requests?" %>
+          </div>
+
+          <div class="field-wrapper">
+            <%= f.label :provisioning_behavior, "Provisioining behavior", aria: { describedby: 'provisioningBehaviorHelp' } %>
+            <%= f.select :provisioning_behavior, Shipit::Repository.provisioning_behaviors.map { |key, value| [ key.titleize, key] } %>
+            <p>
+              <small class="form-text text-muted" id="provisioningBehaviorHelp">
+                When "Allow All", the provisioning label has no affect on dynamic stack provisioning - ALL Pull Requests dynamically provision stacks.<br />
+                When "Allow With Label", dynamic provisioning occurs ONLY for Pull Requests whose labels include the 'Provisioning Label'.<br />
+                When "Prevent With Label", dynmic provisioning will occur for every Pull Request EXCEPT those whose labels include the 'Provisioning Label'.<br />
+              </small>
+            </p>
+          </div>
+          <div class="field-wrapper">
+            <%= f.label :provisioning_label_name, "Provisioining label" %>
+            <%= f.text_field :provisioning_label_name %>
+          </div>
+        </fieldset>
 
         <%= f.submit class: "btn", value: "Save" %>
       <% end %>

--- a/db/migrate/20191231115348_add_per_pr_provisioning_opt_in_and_out_labels_to_repositories.rb
+++ b/db/migrate/20191231115348_add_per_pr_provisioning_opt_in_and_out_labels_to_repositories.rb
@@ -1,0 +1,6 @@
+class AddPerPrProvisioningOptInAndOutLabelsToRepositories < ActiveRecord::Migration[6.0]
+  def change
+    add_column :repositories, :provisioning_behavior, :integer, default: 0
+    add_column :repositories, :provisioning_label_name, :string
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_19_205202) do
+ActiveRecord::Schema.define(version: 2019_12_31_115348) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text "permissions", limit: 65535
@@ -196,6 +196,8 @@ ActiveRecord::Schema.define(version: 2019_12_19_205202) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "provision_pr_stacks", default: false
+    t.integer "provisioning_behavior", default: 0
+    t.string "provisioning_label_name"
     t.index ["owner", "name"], name: "repository_unicity", unique: true
   end
 


### PR DESCRIPTION
Allow repositories to configure per-Pull-Request auto-provisioning
behavior.

When "Dynamically provision stacks for Pull Requests" is enabled:

The "Allow All" (default) beahavior will provision a stack for every
pull request.

The "Allow With Label" behavior will provision a stack for a pull
request if, and only if, the pull request has a label matching the
value provided by the Repository's "Provisioning label" attribute.

The "Prevent With Label" behavior will provision stacks for all pull
requests EXCEPT those with a label matching the value provided by the
Repository's "Provisioning label" attribute.