### PR TITLE
Makes Task commit association optional

### DIFF
--- a/app/models/shipit/deploy.rb
+++ b/app/models/shipit/deploy.rb
@@ -14,6 +14,8 @@ module Shipit
       after_transition any => any, do: :update_last_deploy_time
     end
 
+    belongs_to :until_commit, class_name: 'Commit', required: true, inverse_of: :deploys
+    belongs_to :since_commit, class_name: 'Commit', required: true, inverse_of: :deploys
     has_many :commit_deployments, dependent: :destroy, inverse_of: :task, foreign_key: :task_id do
       GITHUB_STATUSES = {
         'pending' => 'in_progress',

--- a/app/models/shipit/task.rb
+++ b/app/models/shipit/task.rb
@@ -16,8 +16,8 @@ module Shipit
     belongs_to :user, optional: true
     belongs_to :aborted_by, class_name: 'User', optional: true
     belongs_to :stack, counter_cache: true
-    belongs_to :until_commit, class_name: 'Commit'
-    belongs_to :since_commit, class_name: 'Commit'
+    belongs_to :until_commit, class_name: 'Commit', required: false
+    belongs_to :since_commit, class_name: 'Commit', required: false
 
     deferred_touch stack: :updated_at
 

--- a/db/migrate/20200102175621_optional_task_commits.rb
+++ b/db/migrate/20200102175621_optional_task_commits.rb
@@ -1,0 +1,6 @@
+class OptionalTaskCommits < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :tasks, :since_commit_id, true
+    change_column_null :tasks, :until_commit_id, true
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_16_163010) do
+ActiveRecord::Schema.define(version: 2020_01_02_175621) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text "permissions", limit: 65535
@@ -195,6 +195,9 @@ ActiveRecord::Schema.define(version: 2019_12_16_163010) do
     t.string "name", limit: 39, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "provision_pr_stacks", default: false
+    t.integer "provisioning_behavior", default: 0
+    t.string "provisioning_label_name"
     t.index ["owner", "name"], name: "repository_unicity", unique: true
   end
 
@@ -218,6 +221,8 @@ ActiveRecord::Schema.define(version: 2019_12_16_163010) do
     t.boolean "merge_queue_enabled", default: false, null: false
     t.datetime "last_deployed_at"
     t.integer "repository_id", null: false
+    t.datetime "archived_since"
+    t.index ["archived_since"], name: "index_stacks_on_archived_since"
     t.index ["repository_id", "environment"], name: "stack_unicity", unique: true
     t.index ["repository_id"], name: "index_stacks_on_repository_id"
   end
@@ -236,8 +241,8 @@ ActiveRecord::Schema.define(version: 2019_12_16_163010) do
 
   create_table "tasks", force: :cascade do |t|
     t.integer "stack_id", limit: 4, null: false
-    t.integer "since_commit_id", limit: 4, null: false
-    t.integer "until_commit_id", limit: 4, null: false
+    t.integer "since_commit_id", limit: 4
+    t.integer "until_commit_id", limit: 4
     t.string "status", limit: 10, default: "pending", null: false
     t.datetime "created_at"
     t.datetime "updated_at"

--- a/test/dummy/db/seeds.rb
+++ b/test/dummy/db/seeds.rb
@@ -198,8 +198,6 @@ module Shipit
     write_output(rollback)
 
     task = stack.tasks.create!(
-      since_commit_id: stack.last_deployed_commit.id,
-      until_commit_id: stack.last_deployed_commit.id,
       status: "success",
       user: users.sample,
       definition: TaskDefinition.new('restart',

--- a/test/fixtures/shipit/tasks.yml
+++ b/test/fixtures/shipit/tasks.yml
@@ -29,8 +29,6 @@ shipit2:
 shipit_restart:
   id: 3
   user: walrus
-  since_commit_id: 2 # second
-  until_commit_id: 2 # second
   type: Shipit::Task
   stack: shipit
   status: success


### PR DESCRIPTION
Tasks do not need to be associated with particular commits; it is sometimes desirable to programatically create a Stack and a Task in immediate succession, prior to the GithubSyncJob having executed, to perform a provisioning step which must execute prior to a project-defined deployment; for this kind of task, an association with a commit range is not meaningful or useful.