### PR TITLE
Add environment_url on successful deployment status

### DIFF
--- a/app/models/shipit/commit_deployment_status.rb
+++ b/app/models/shipit/commit_deployment_status.rb
@@ -47,10 +47,21 @@ module Shipit
       client.create_deployment_status(
         commit_deployment.api_url,
         status,
-        accept: 'application/vnd.github.flash-preview+json',
-        target_url: url_helpers.stack_deploy_url(stack, task),
-        description: description.truncate(DESCRIPTION_CHARACTER_LIMIT_ON_GITHUB),
+        **params,
       )
+    end
+
+    def params
+      {}.tap do |hash|
+        hash[:accept] = 'application/vnd.github.flash-preview+json'
+        hash[:target_url] = url_helpers.stack_deploy_url(stack, task)
+        hash[:description] = description.truncate(DESCRIPTION_CHARACTER_LIMIT_ON_GITHUB)
+        hash[:environment_url] = stack.deploy_url if deployed?
+      end
+    end
+
+    def deployed?
+      status == "success"
     end
 
     def url_helpers

--- a/test/models/commit_deployment_status_test.rb
+++ b/test/models/commit_deployment_status_test.rb
@@ -37,5 +37,19 @@ module Shipit
 
       status.create_on_github!
     end
+
+    test 'includes deployment url when the deployment succeeds' do
+      deployment = shipit_commit_deployments(:shipit_deploy_second)
+
+      status = deployment.statuses.create!(status: 'success')
+      stack = status.stack
+      stack.deploy_url = "stack-deploy-url"
+      create_status_response = stub(id: 'abcd', url: 'https://github.com/status/abcd')
+      status.author.github_api.expects(:create_deployment_status).with do |*_args, **kwargs|
+        kwargs[:environment_url] == 'stack-deploy-url'
+      end.returns(create_status_response)
+
+      status.create_on_github!
+    end
   end
 end


### PR DESCRIPTION
When creating a deployment status event for a successful deployment,
let's add the `environment_url` to the payload we send to GitHub. The
idea is that this gets us whatever awesome features with which the GitHub API
uses this value - automatic linking to the deployment environment in
the PR - but also we can then pass this through to systems consuming
the deployment events to provide additional functionality.

References
----------

- https://developer.github.com/changes/2016-04-06-deployment-and-deployment-status-enhancements/#link-to-a-live-deployment