### PR TITLE
Add mechanism for mounting application to add links to stack header

### DIFF
--- a/app/models/shipit/commit_deployment_status.rb
+++ b/app/models/shipit/commit_deployment_status.rb
@@ -50,6 +50,7 @@ module Shipit
         accept: 'application/vnd.github.flash-preview+json',
         target_url: url_helpers.stack_deploy_url(stack, task),
         description: description.truncate(DESCRIPTION_CHARACTER_LIMIT_ON_GITHUB),
+        environment_url: stack.deploy_url,
       )
     end
 

--- a/app/models/shipit/deploy.rb
+++ b/app/models/shipit/deploy.rb
@@ -21,7 +21,9 @@ module Shipit
         'pending' => 'pending',
         'running' => 'in_progress',
         'failed' => 'failure',
+        'timedout' => 'failure',
         'success' => 'success',
+        'faulty' => 'error',
         'error' => 'error',
         'aborted' => 'error',
       }.freeze
@@ -33,7 +35,8 @@ module Shipit
             Rails.logger.info(
               "Creating #{github_status} deploy status for deployment #{deployment.id}. "\
               "Commit: #{deployment.sha}, Github id: #{deployment.github_id}, "\
-              "Repo: #{deployment.stack.repo_name}, Environment: #{deployment.stack.environment}",
+              "Repo: #{deployment.stack.repo_name}, Environment: #{deployment.stack.environment}, "\
+              "API Url: #{deployment.api_url}.",
             )
             deployment.statuses.create!(status: github_status)
           end
@@ -42,7 +45,8 @@ module Shipit
             Rails.logger.warn(
               "No GitHub status for task status #{task_status}. "\
               "Commit: #{deployment.sha}, Github id: #{deployment.github_id}, "\
-              "Repo: #{deployment.stack.repo_name}, Environment: #{deployment.stack.environment}",
+              "Repo: #{deployment.stack.repo_name}, Environment: #{deployment.stack.environment}, "\
+              "API Url: #{deployment.api_url}.",
             )
           end
         end

--- a/app/views/shipit/stacks/_header.html.erb
+++ b/app/views/shipit/stacks/_header.html.erb
@@ -41,6 +41,8 @@
         </ul>
       </li>
     <% end %>
+
+    <%= render partial: 'shipit/stacks/links', locals: { stack: stack } %>
   </ul>
 
   <ul class="nav__list nav__list--secondary">

--- a/app/views/shipit/stacks/_links.html.erb
+++ b/app/views/shipit/stacks/_links.html.erb
@@ -1,0 +1,1 @@
+<%# Placeholder to be used by the host application %>

--- a/test/models/commit_deployment_status_test.rb
+++ b/test/models/commit_deployment_status_test.rb
@@ -17,6 +17,7 @@ module Shipit
         accept: "application/vnd.github.flash-preview+json",
         target_url: "http://shipit.com/shopify/shipit-engine/production/deploys/#{@task.id}",
         description: "walrus triggered the deploy of shopify/shipit-engine/production to #{@deployment.short_sha}",
+        environment_url: "https://shipit.shopify.com",
       ).returns(response)
 
       @status.create_on_github!
@@ -33,6 +34,20 @@ module Shipit
       create_status_response = stub(id: 'abcd', url: 'https://github.com/status/abcd')
       status.author.github_api.expects(:create_deployment_status).with do |*_args, **kwargs|
         kwargs[:description].size <= limit
+      end.returns(create_status_response)
+
+      status.create_on_github!
+    end
+
+    test 'includes deployment url when the deployment succeeds' do
+      deployment = shipit_commit_deployments(:shipit_deploy_second)
+
+      status = deployment.statuses.create!(status: 'success')
+      stack = status.stack
+      stack.deploy_url = "stack-deploy-url"
+      create_status_response = stub(id: 'abcd', url: 'https://github.com/status/abcd')
+      status.author.github_api.expects(:create_deployment_status).with do |*_args, **kwargs|
+        kwargs[:environment_url] == 'stack-deploy-url'
       end.returns(create_status_response)
 
       status.create_on_github!


### PR DESCRIPTION
Give the mounting application a way to define additional links which
apply to stacks across the system rather than per-stack.