### PR TITLE
Prevent GithubSyncJob from blowing up if commit already exists

### DIFF
--- a/app/jobs/shipit/github_sync_job.rb
+++ b/app/jobs/shipit/github_sync_job.rb
@@ -26,7 +26,13 @@ module Shipit
     end
 
     def append_commit(gh_commit)
-      @stack.commits.create_from_github!(gh_commit)
+      if commit = @stack.commits.by_sha(gh_commit.sha)
+        return commit
+      else
+        @stack.commits.create_from_github!(gh_commit)
+      end
+    rescue ActiveRecord::RecordNotUnique
+      retry
     end
 
     def fetch_missing_commits(&block)


### PR DESCRIPTION
https://sentry.io/organizations/power-home-remodeling-group/issues/1515143372/?end=2020-02-18T04%3A59%3A59&project=1833592&query=is%3Aunresolved&start=2020-02-14T05%3A00%3A00&utc=false

My current thinking is that when we create a stack and associate the
PR we enqueue two jobs. The GithubSyncJob and the
RefreshPullRequestJob. These both run concurrently. In some cases, the
GithubSyncJob runs and attempts to find the list of commits for the
stack which haven't yet been created - this includes the PR's head ref:

https://github.com/powerhome/shipit-engine/blob/master/app/jobs/shipit/github_sync_job.rb#L32-L44

Then the RefreshPullRequestJob runs and creates the Shipit::Commit
object for the head ref of the branch:

https://github.com/powerhome/shipit-engine/blob/pr-review-stacks/app/models/shipit/pull_request.rb#L243

Then the GithubSyncJob gets scheduled and attempts to create the
Shipit::Commit object for the head ref and blows up:

https://github.com/powerhome/shipit-engine/blob/master/app/jobs/shipit/github_sync_job.rb#L29