### PR TITLE
GithubSyncJob must run once before syncing pull requests

### DIFF
--- a/app/jobs/shipit/refresh_pull_request_job.rb
+++ b/app/jobs/shipit/refresh_pull_request_job.rb
@@ -3,6 +3,8 @@ module Shipit
     queue_as :default
 
     def perform(pull_request)
+      raise Stack::NotYetSynced if pull_request.stack.commits.blank?
+
       pull_request.refresh!
       MergePullRequestsJob.perform_later(pull_request.stack)
     end

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -2,6 +2,8 @@ require 'fileutils'
 
 module Shipit
   class Stack < ActiveRecord::Base
+    NotYetSynced = Class.new(StandardError)
+
     module NoDeployedCommit
       extend self
 


### PR DESCRIPTION
Require at least one GithubSyncJob has been successful for a stack
before refreshing its pull requests. When a pull requests is created
before stack sync it will create a detatched Shipit::Commit record for
its head ref. When GithubSyncJob runs afterward the
Sidekiq/Shipit::GithubSyncJob perpetually emits an
ActiveRecord::RecordNotUnique error becuase the GithubSyncJob attempts
to create the PullRequst's head ref Shipit::Commit again in a
non-detatched state and violates the index_commits_on_sha_and_stack_id
uniqueness index.