### PR TITLE
Capture github user information on pull request creation

### DIFF
--- a/app/models/shipit/pull_request.rb
+++ b/app/models/shipit/pull_request.rb
@@ -247,7 +247,7 @@ module Shipit
     end
 
     def github_pull_request=(github_pull_request)
-      user = User.find_by(login: github_pull_request.user.login) || Shipit::AnonymousUser.new
+      user = User.find_or_create_by_login!(github_pull_request.user.login) || Shipit::AnonymousUser.new
 
       self.github_id = github_pull_request.id
       self.api_url = github_pull_request.url


### PR DESCRIPTION
Currently, we only associate the pull request with a user if we've
seen them before. This allows the correct assignment of the Github
user if this our first contact with them.