### PR TITLE
[GOG-86] Introduces PR event and emits it after every changes

### DIFF
--- a/app/models/shipit/hook.rb
+++ b/app/models/shipit/hook.rb
@@ -52,6 +52,7 @@ module Shipit
       deployable_status
       merge_status
       merge
+      pull_request
     ).freeze
 
     belongs_to :stack, required: false


### PR DESCRIPTION
Allow pull request events to be emitted by the `Hook` class. Along with the `merge_status` events, the `pull_request` event is sent after every time a PR is saved.