### PR TITLE
[GOG-153] Prevent erroneously marking deployments as dead soon after they start

### DIFF
--- a/app/jobs/shipit/perform_task_job.rb
+++ b/app/jobs/shipit/perform_task_job.rb
@@ -15,6 +15,7 @@ module Shipit
     end
 
     def run
+      @task.ping
       @task.run!
       checkout_repository
       perform_task
@@ -62,6 +63,10 @@ module Shipit
 
     def checkout_repository
       unless @commands.fetched?(@task.until_commit).tap(&:run).success?
+        # acquire_git_cache_lock can take upto 15 seconds
+        # to process. Try to make sure that the job isn't
+        # marked dead while we attempt to acquire the lock.
+        @task.ping
         @task.acquire_git_cache_lock do
           unless @commands.fetched?(@task.until_commit).tap(&:run).success?
             capture! @commands.fetch

--- a/app/jobs/shipit/reap_dead_tasks_job.rb
+++ b/app/jobs/shipit/reap_dead_tasks_job.rb
@@ -7,13 +7,33 @@ module Shipit
     queue_as :default
 
     def perform
-      zombie_tasks = Task.where(status: ZOMBIE_STATES).reject(&:alive?)
-
       Rails.logger.info("Reaping #{zombie_tasks.size} running tasks.")
       zombie_tasks.each do |task|
         Rails.logger.info("Reaping task #{task.id}: #{task.title}")
         task.report_dead!
       end
+    end
+
+    MINUTES_TO_CONSIDER_TASK_RECENT = 5
+    private_constant :MINUTES_TO_CONSIDER_TASK_RECENT
+    def self.recently_created_at
+      MINUTES_TO_CONSIDER_TASK_RECENT.minutes.ago
+    end
+
+    private
+
+    def zombie_tasks
+      @zombie_tasks ||= Task
+                        .where(status: ZOMBIE_STATES)
+                        .where(
+                          "created_at <= :recently",
+                          recently: recently_created_at,
+                        )
+                        .reject(&:alive?)
+    end
+
+    def recently_created_at
+      self.class.recently_created_at
     end
   end
 end

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -62,17 +62,6 @@ module Shipit
       }
     end
 
-    def env
-      {
-        'ENVIRONMENT' => environment,
-        'LAST_DEPLOYED_SHA' => last_deployed_commit.sha,
-        'GITHUB_REPO_OWNER' => repository.owner,
-        'GITHUB_REPO_NAME' => repository.name,
-        'DEPLOY_URL' => deploy_url,
-        'BRANCH' => branch,
-      }
-    end
-
     def repository
       super || build_repository
     end

--- a/app/models/shipit/task.rb
+++ b/app/models/shipit/task.rb
@@ -4,7 +4,7 @@ module Shipit
 
     ConcurrentTaskRunning = Class.new(StandardError)
 
-    PRESENCE_CHECK_TIMEOUT = 15
+    PRESENCE_CHECK_TIMEOUT = 30
     ACTIVE_STATUSES = %w(pending running aborting).freeze
     COMPLETED_STATUSES = %w(success flapping faulty validating).freeze
     UNSUCCESSFUL_STATUSES = %w(error failed aborted flapping timedout faulty).freeze


### PR DESCRIPTION
There appears to be a race condition between the time when the
PerformTaskJob marks a task as "running" and when the newly added
RemoveDeadTasks job attempts to reap dead tasks.

In some cases a deployment is almost immediately marked as dead after
it starts. We believe this is because there critical section in which
PerformTaskJob marks a task as running and ReapDeadTaskJob is run in
which newly a task can be transitioned to a "running" status, but not
yet marked alive in which a newly created task will be considered a
"dead task" by the ReapDeaTasks job.

This changeset aims a two pronged approach at preventing this
race. First it makes the ReapDeadTasksJob less aggressive in its
consideration of tasks as "dead" - it will now only consider tasks in
a "running" or "aborted" state which are missing an "alive" monitor
AND are 5 at least minutes old.

Second, when PerformTaskJob starts working a task the task will ping
the "alive" monitor as soon as the task is marked as running. The
implementation of reporting that tasks are "alive" is somewhat
imperfect, in that it it doesn't happen until we attempt to capture
command output. There are therefore several things which happen
between starting the task and the first command happening, namely one
or two checks that the git repo is already checked out and a wait on a
cache lock, whose timeout is also 15 seconds. This means a large
opportunity for the "alive" status to expire. We should probably
ensure that the task is considered alive for a period long enough to
span this (maybe 30 seconds rather than 15), as well as ping after
each check of `fetched?`.

References
----------

- [Task marked as running, but not yet alive](https://github.com/Shopify/shipit-engine/blob/d48ceb4ffc21afbdf2701ce8c3a8936268afc3d5/app/jobs/shipit/perform_task_job.rb#L18)
- [Task first marked as alive](https://github.com/Shopify/shipit-engine/blob/d48ceb4ffc21afbdf2701ce8c3a8936268afc3d5/app/jobs/shipit/perform_task_job.rb#L81)