### PR TITLE
Fix return type of Stack#trigger_continuous_delivery

### DIFF
--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -171,8 +171,15 @@ module Shipit
     def trigger_continuous_delivery
       commit = next_commit_to_deploy
 
-      return continuous_delivery_resumed! if should_resume_continuous_delivery?(commit)
-      return continuous_delivery_delayed! if should_delay_continuous_delivery?(commit)
+      if should_resume_continuous_delivery?(commit)
+        continuous_delivery_resumed!
+        return
+      end
+
+      if should_delay_continuous_delivery?(commit)
+        continuous_delivery_delayed!
+        return
+      end
 
       begin
         trigger_deploy(commit, Shipit.user, env: cached_deploy_spec.default_deploy_env)

--- a/test/models/stacks_test.rb
+++ b/test/models/stacks_test.rb
@@ -500,7 +500,9 @@ module Shipit
 
       assert_no_enqueued_jobs do
         assert_no_difference -> { Deploy.count } do
-          @stack.trigger_continuous_delivery
+          value = @stack.trigger_continuous_delivery
+
+          assert_nil value
         end
       end
     end


### PR DESCRIPTION
In 8c6ad042d768b2c743b6ca468c9ad0549a98e298 we accidentally changed
the return types of this method when bailing out early due to stack
readiness. Here we aim to restore the original "always nil" return
type.

References
----------

- https://github.com/powerhome/shipit-engine/commit/8c6ad042d768b2c743b6ca468c9ad0549a98e298
- https://ci.powerhrg.com/job/powerhome/job/milano/job/PR-283/5/console