### PR TITLE
[GOG-129] Adds pull request assignees to Ship It

### DIFF
--- a/app/models/shipit/pull_request.rb
+++ b/app/models/shipit/pull_request.rb
@@ -43,6 +43,7 @@ module Shipit
     belongs_to :merge_requested_by, class_name: 'Shipit::User', optional: true
     has_one :merge_commit, class_name: 'Shipit::Commit'
     belongs_to :user, optional: true
+    has_many :assignees, class_name: :User, through: :pull_request_assignments, source: :user
 
     deferred_touch stack: :updated_at
 

--- a/app/models/shipit/pull_request.rb
+++ b/app/models/shipit/pull_request.rb
@@ -270,11 +270,7 @@ module Shipit
     end
 
     def find_and_assign_users(pr_assignees)
-      pr_assignees.map do |assignee|
-        assignee_user = User.find_by(login: assignee.login)
-        next unless assignee_user
-        assignee_user
-      end
+      pr_assignees.map { |assignee| User.find_by(login: assignee.login) }.compact
     end
 
     def merge_message

--- a/app/models/shipit/pull_request.rb
+++ b/app/models/shipit/pull_request.rb
@@ -43,6 +43,7 @@ module Shipit
     belongs_to :merge_requested_by, class_name: 'Shipit::User', optional: true
     has_one :merge_commit, class_name: 'Shipit::Commit'
     belongs_to :user, optional: true
+    has_many :pull_request_assignments
     has_many :assignees, class_name: :User, through: :pull_request_assignments, source: :user
 
     deferred_touch stack: :updated_at
@@ -265,6 +266,11 @@ module Shipit
       self.base_ref = github_pull_request.base.ref
       self.base_commit = find_or_create_commit_from_github_by_sha!(github_pull_request.base.sha, detached: true)
       self.user = user
+      self.assignees = find_and_assign_users(github_pull_request.assignees)
+    end
+
+    def find_and_assign_users(pr_assignees)
+      pr_assignees.map { |assignee| User.find_by(login: assignee.login) || Shipit::AnonymousUser.new }
     end
 
     def merge_message

--- a/app/models/shipit/pull_request.rb
+++ b/app/models/shipit/pull_request.rb
@@ -270,7 +270,11 @@ module Shipit
     end
 
     def find_and_assign_users(pr_assignees)
-      pr_assignees.map { |assignee| User.find_by(login: assignee.login) || Shipit::AnonymousUser.new }
+      pr_assignees.map do |assignee|
+        assignee_user = User.find_by(login: assignee.login)
+        next unless assignee_user
+        assignee_user
+      end
     end
 
     def merge_message

--- a/app/models/shipit/pull_request_assignment.rb
+++ b/app/models/shipit/pull_request_assignment.rb
@@ -1,0 +1,8 @@
+module Shipit
+  class PullRequestAssignment < ActiveRecord::Base
+    belongs_to :pull_request, required: true
+    belongs_to :user, required: true
+
+    validates :user_id, uniqueness: {scope: :pull_request_id}
+  end
+end

--- a/app/models/shipit/user.rb
+++ b/app/models/shipit/user.rb
@@ -3,6 +3,7 @@ module Shipit
     DEFAULT_AVATAR = URI.parse('https://avatars.githubusercontent.com/u/583231?')
 
     has_many :memberships
+    has_many :pull_request_assignments
     has_many :teams, through: :memberships
     has_many :authored_commits, class_name: :Commit, foreign_key: :author_id, inverse_of: :author
     has_many :commits, foreign_key: :committer_id, inverse_of: :committer

--- a/app/serializers/shipit/pull_request_serializer.rb
+++ b/app/serializers/shipit/pull_request_serializer.rb
@@ -6,6 +6,7 @@ module Shipit
     has_one :merge_requested_by
     has_one :head, serializer: ShortCommitSerializer
     has_one :user
+    has_many :assignees, serializer: UserSerializer
 
     attributes :id, :number, :title, :github_id, :additions, :deletions, :state, :merge_status, :mergeable,
                :merge_requested_at, :rejection_reason, :html_url, :branch, :base_ref

--- a/db/migrate/20200416194056_create_pull_request_assignments.rb
+++ b/db/migrate/20200416194056_create_pull_request_assignments.rb
@@ -1,0 +1,8 @@
+class CreatePullRequestAssignments < ActiveRecord::Migration[6.0]
+  def change
+    create_table :pull_request_assignments do |t|
+      t.references :pull_request
+      t.references :user
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_26_211925) do
+ActiveRecord::Schema.define(version: 2020_04_16_194056) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text "permissions", limit: 65535
@@ -143,6 +143,13 @@ ActiveRecord::Schema.define(version: 2020_02_26_211925) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["task_id"], name: "index_output_chunks_on_task_id"
+  end
+
+  create_table "pull_request_assignments", force: :cascade do |t|
+    t.integer "pull_request_id"
+    t.integer "user_id"
+    t.index ["pull_request_id"], name: "index_pull_request_assignments_on_pull_request_id"
+    t.index ["user_id"], name: "index_pull_request_assignments_on_user_id"
   end
 
   create_table "pull_requests", force: :cascade do |t|

--- a/test/fixtures/shipit/pull_request_assignments.yml
+++ b/test/fixtures/shipit/pull_request_assignments.yml
@@ -1,0 +1,3 @@
+walrus_shopify_developers:
+  pull_request: shipit_pending
+  user: walrus

--- a/test/models/pull_request_assignment_test.rb
+++ b/test/models/pull_request_assignment_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+module Shipit
+  class PullRequestAssignmentTest < ActiveSupport::TestCase
+    setup do
+      @assignment = shipit_pull_request_assignments(:walrus_shopify_developers)
+    end
+
+    test "no duplicates are accepted" do
+      assignment = PullRequestAssignment.new(user: @assignment.user, pull_request: @assignment.pull_request)
+      refute assignment.valid?
+    end
+  end
+end

--- a/test/models/pull_request_test.rb
+++ b/test/models/pull_request_test.rb
@@ -107,6 +107,13 @@ module Shipit
             login: 'bob',
             site_admin: false,
           ),
+          assignees: [
+            stub(
+              id: 1234,
+              login: 'bob',
+              site_admin: false,
+            ),
+          ],
         ),
       )
 
@@ -150,6 +157,7 @@ module Shipit
       assert_predicate pull_request, :pending?
       assert_equal 'super-branch', pull_request.branch
       assert_equal user, pull_request.user
+      assert_equal [user], pull_request.assignees
 
       assert_not_nil pull_request.head
       assert_predicate pull_request.head, :detached?


### PR DESCRIPTION
Adds a relation between a pull request and a shipit user in order to track PR assignees.