### PR TITLE
[GOG-156] Associate users with review requests when they are created

### DIFF
--- a/app/models/shipit/pull_request.rb
+++ b/app/models/shipit/pull_request.rb
@@ -141,12 +141,14 @@ module Shipit
       pull_request
     end
 
-    def self.assign_to_stack!(stack, number)
+    def self.assign_to_stack!(stack, number, user)
       pull_request = PullRequest.find_or_create_by!(
         stack: stack,
         number: number,
         review_request: true,
-      )
+      ) do |pr|
+        pr.user = user
+      end
       pull_request.schedule_refresh!
       pull_request
     end

--- a/test/models/pull_request_test.rb
+++ b/test/models/pull_request_test.rb
@@ -11,14 +11,14 @@ module Shipit
     test ".assign_to_stack! associates the pull request with a stack and schedules a pull request refresh" do
       pull_request = nil
       assert_enqueued_with(job: RefreshPullRequestJob) do
-        pull_request = PullRequest.assign_to_stack!(@stack, 100)
+        pull_request = PullRequest.assign_to_stack!(@stack, 100, @user)
       end
       assert_predicate pull_request, :persisted?
     end
 
     test ".assign_to_stack! is idempotent" do
       assert_difference -> { PullRequest.count }, +1 do
-        5.times { PullRequest.assign_to_stack!(@stack, 100) }
+        5.times { PullRequest.assign_to_stack!(@stack, 100, @user) }
       end
     end
 


### PR DESCRIPTION
Given the a review request is created as the result of a Github Pull
Request event, we already know the user who created the pull request
when we create the Shipit::PullRequest object. Setting the user
earlier allows us to include it in hook payload that we can use to
message the user who opened the PR.

Notes
-------

This requires work in Milano to make sure the signature change 
to the `assign_to_stack` method lines up.

References
----------

- https://nitro.powerhrg.com/runway/backlog_items/GOG-156