### PR TITLE
Add provision_status state machine to review stacks

### DIFF
--- a/db/migrate/20200518192351_add_provision_status_to_stacks.rb
+++ b/db/migrate/20200518192351_add_provision_status_to_stacks.rb
@@ -1,0 +1,11 @@
+class AddProvisionStatusToStacks < ActiveRecord::Migration[6.0]
+  def up
+    add_column :stacks, :provision_status, :string, null: false, default: :not_provisioned
+    add_index :stacks, :provision_status
+  end
+
+  def down
+    remove_index :stacks, :provision_status
+    remove_column :stacks, :provision_status
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_27_135152) do
+ActiveRecord::Schema.define(version: 2020_05_18_192351) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text "permissions", limit: 65535
@@ -236,9 +236,11 @@ ActiveRecord::Schema.define(version: 2020_04_27_135152) do
     t.datetime "archived_since"
     t.string "lock_reason_code"
     t.boolean "auto_provisioned", default: false
+    t.string "provision_status", default: "not_provisioned", null: false
     t.index ["archived_since"], name: "index_stacks_on_archived_since"
     t.index ["auto_provisioned"], name: "index_stacks_on_auto_provisioned"
     t.index ["lock_reason_code"], name: "index_stacks_on_lock_reason_code"
+    t.index ["provision_status"], name: "index_stacks_on_provision_status"
     t.index ["repository_id", "environment"], name: "stack_unicity", unique: true
     t.index ["repository_id"], name: "index_stacks_on_repository_id"
   end

--- a/test/models/shipit/stacks_provision_status_test.rb
+++ b/test/models/shipit/stacks_provision_status_test.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+# frozen_string_literal: true
+require 'test_helper'
+
+module Shipit
+  class StackProvisionStatusTest < ActiveSupport::TestCase
+    test "stacks default to not_provisioned state" do
+      stack = Shipit::Stack.new
+
+      assert_equal 'not_provisioned', stack.provision_status
+    end
+
+    test "non-review stacks don't transition" do
+      stack = Shipit::Stack.new
+      stack.schedule_provision
+
+      assert_equal 'not_provisioned', stack.provision_status
+    end
+
+    test "review stacks that have yet to be provisioned can be scheduled for provisioning" do
+      stack = review_stack(provision_status: :not_provisioned)
+
+      stack.schedule_provision
+
+      assert_equal 'pending_provision', stack.provision_status
+    end
+
+    test "review stacks that have been scheduled for provisioning can be provisioned" do
+      stack = review_stack(provision_status: :pending_provision)
+
+      stack.provision
+
+      assert_equal 'provisioning', stack.provision_status
+    end
+
+    test "review stacks that have been provisioning can be marked as provisioned" do
+      stack = review_stack(provision_status: :provisioning)
+
+      stack.provisioned
+
+      assert_equal 'provisioned', stack.provision_status
+    end
+
+    test "review stacks which are provisioning can fail to provision" do
+      stack = review_stack(provision_status: :provisioning)
+
+      stack.fail_provisioning
+
+      assert_equal 'provisioning_error', stack.provision_status
+    end
+
+    test "review stacks that have previously failed to provision can be scheduled for provisioning" do
+      stack = review_stack(provision_status: :provisioning_error)
+
+      stack.schedule_provision
+
+      assert_equal 'pending_provision', stack.provision_status
+    end
+
+    test "review stacks that have been provisioned can be scheduled for deprovisioning" do
+      stack = review_stack(provision_status: :provisioned)
+
+      stack.schedule_deprovision
+
+      assert_equal 'pending_deprovision', stack.provision_status
+    end
+
+    test "review stacks that have been scheduled for deprovisioning can be deprovisioned" do
+      stack = review_stack(provision_status: :pending_deprovision)
+
+      stack.deprovision
+
+      assert_equal 'deprovisioning', stack.provision_status
+    end
+
+    test "review stacks that have been deprovisioning can be marked as deprovisioned" do
+      stack = review_stack(provision_status: :deprovisioning)
+
+      stack.deprovisioned
+
+      assert_equal 'deprovisioned', stack.provision_status
+    end
+
+    test "review stacks that have been deprovisioning can fail deprovisioning" do
+      stack = review_stack(provision_status: :deprovisioning)
+
+      stack.fail_deprovisioning
+
+      assert_equal 'deprovisioning_error', stack.provision_status
+    end
+
+    test "review stacks that have failed to deprovisioncan be scheduled for deprovisioning" do
+      stack = review_stack(provision_status: :deprovisioning_error)
+
+      stack.schedule_deprovision
+
+      assert_equal 'pending_deprovision', stack.provision_status
+    end
+
+    test "review stacks that have been deprovisioned can be scheduled for provisioning" do
+      stack = review_stack(provision_status: :deprovisioned)
+
+      stack.schedule_provision
+
+      assert_equal 'pending_provision', stack.provision_status
+    end
+
+    def review_stack(provision_status: :not_provisioned)
+      stack = shipit_stacks(:shipit)
+      stack.auto_provisioned = true
+      stack.provision_status = provision_status
+
+      stack.save!
+
+      stack
+    end
+  end
+end


### PR DESCRIPTION
In order to facilitate provisioning, provisioned-resource limits,
etc. for review stacks we want to introduce a proper "provisioning
status" to indicate the state of the Review Environment.

Note, this is a response to design feedback form the upstream
repository maintainers.

References
----------

- https://nitro.powerhrg.com/runway/backlog_items/GOG-179
- https://github.com/Shopify/shipit-engine/pull/991#issuecomment-575097398