### PR TITLE
Expose provisioning lifecycle hooks

### DIFF
--- a/app/models/shipit/provisioning_handler.rb
+++ b/app/models/shipit/provisioning_handler.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Shipit
+  module ProvisioningHandler
+    class << self
+      def handlers
+        @handlers ||= reset!
+      end
+
+      def reset!
+        @handlers = {}
+      end
+
+      def register(github_repo_name, callable)
+        handlers[github_repo_name] = callable if callable.present?
+      end
+
+      def for_stack(stack)
+        handlers[stack.github_repo_name] || handlers[:default] || ProvisioningHandler::Base
+      end
+    end
+  end
+end

--- a/app/models/shipit/provisioning_handler/base.rb
+++ b/app/models/shipit/provisioning_handler/base.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Shipit
+  module ProvisioningHandler
+    class Base
+      def initialize(stack)
+        @stack = stack
+      end
+
+      def up
+        # Intentionally a noop
+      end
+
+      def down
+        # Intentionally a noop
+      end
+
+      private
+
+      attr_accessor(
+        :stack,
+      )
+    end
+  end
+end

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -5,59 +5,42 @@ module Shipit
   class Stack < ActiveRecord::Base
     NotYetSynced = Class.new(StandardError)
 
-    state_machine :provision_status, initial: :not_provisioned do
-      state :not_provisioned
-      state :pending_provision
-      state :provisioning
-      state :provisioning_error
+    state_machine :provision_status, initial: :deprovisioned do
       state :provisioned
-      state :pending_deprovision
+      state :provisioning
       state :deprovisioning
-      state :deprovisioning_error
       state :deprovisioned
 
-      event :schedule_provision do
-        transition(
-          %i(not_provisioned deprovisioned provisioning_error) => :pending_provision,
-          if: -> (stack) { stack.auto_provisioned? }
-        )
-      end
-
-      before_transition pending_provision: :provisioning do |stack, _|
-        stack.provisioner.up
-      end
       event :provision do
-        transition pending_provision: :provisioning, if: -> (stack) { stack.auto_provisioned? }
+        transition deprovisioned: :provisioning, if: -> (stack) { stack.auto_provisioned? }
       end
 
-      event :provisioned do
+      event :provision_success do
         transition provisioning: :provisioned, if: -> (stack) { stack.auto_provisioned? }
       end
 
-      event :fail_provisioning do
-        transition provisioning: :provisioning_error, if: -> (stack) { stack.auto_provisioned? }
+      event :provision_failure do
+        transition provisioning: :deprovisioned, if: -> (stack) { stack.auto_provisioned? }
       end
 
-      event :schedule_deprovision do
-        transition(
-          %i(provisioned deprovisioning_error) => :pending_deprovision,
-          if: -> (stack) { stack.auto_provisioned? }
-        )
-      end
-
-      before_transition pending_deprovision: :deprovisioning do |stack, _|
-        stack.provisioner.down
-      end
       event :deprovision do
-        transition pending_deprovision: :deprovisioning, if: -> (stack) { stack.auto_provisioned? }
+        transition provisioned: :deprovisioning, if: -> (stack) { stack.auto_provisioned? }
       end
 
-      event :deprovisioned do
+      event :deprovision_success do
         transition deprovisioning: :deprovisioned, if: -> (stack) { stack.auto_provisioned? }
       end
 
-      event :fail_deprovisioning do
-        transition deprovisioning: :deprovisioning_error, if: -> (stack) { stack.auto_provisioned? }
+      event :deprovision_failure do
+        transition deprovisioning: :provisioned, if: -> (stack) { stack.auto_provisioned? }
+      end
+
+      after_transition deprovisioned: :provisioning do |stack, _|
+        stack.provisioner.up
+      end
+
+      after_transition provisioned: :deprovisioning do |stack, _|
+        stack.provisioner.down
       end
     end
 

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -23,6 +23,9 @@ module Shipit
         )
       end
 
+      before_transition pending_provision: :provisioning do |stack, _|
+        stack.provisioner.up
+      end
       event :provision do
         transition pending_provision: :provisioning, if: -> (stack) { stack.auto_provisioned? }
       end
@@ -42,6 +45,9 @@ module Shipit
         )
       end
 
+      before_transition pending_deprovision: :deprovisioning do |stack, _|
+        stack.provisioner.down
+      end
       event :deprovision do
         transition pending_deprovision: :deprovisioning, if: -> (stack) { stack.auto_provisioned? }
       end
@@ -53,6 +59,14 @@ module Shipit
       event :fail_deprovisioning do
         transition deprovisioning: :deprovisioning_error, if: -> (stack) { stack.auto_provisioned? }
       end
+    end
+
+    def provisioner
+      provisioner_class.new(self)
+    end
+
+    def provisioner_class
+      ProvisioningHandler.for_stack(self)
     end
 
     module NoDeployedCommit

--- a/db/migrate/20200618021438_change_provision_status_default_to_deprovisioned.rb
+++ b/db/migrate/20200618021438_change_provision_status_default_to_deprovisioned.rb
@@ -1,0 +1,5 @@
+class ChangeProvisionStatusDefaultToDeprovisioned < ActiveRecord::Migration[6.0]
+  def change
+    change_column_default :stacks, :provision_status, :deprovisioned
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_18_192351) do
+ActiveRecord::Schema.define(version: 2020_06_18_021438) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text "permissions", limit: 65535
@@ -236,7 +236,7 @@ ActiveRecord::Schema.define(version: 2020_05_18_192351) do
     t.datetime "archived_since"
     t.string "lock_reason_code"
     t.boolean "auto_provisioned", default: false
-    t.string "provision_status", default: "not_provisioned", null: false
+    t.string "provision_status", default: "deprovisioned", null: false
     t.index ["archived_since"], name: "index_stacks_on_archived_since"
     t.index ["auto_provisioned"], name: "index_stacks_on_auto_provisioned"
     t.index ["lock_reason_code"], name: "index_stacks_on_lock_reason_code"

--- a/test/jobs/perform_task_job_test.rb
+++ b/test/jobs/perform_task_job_test.rb
@@ -21,7 +21,7 @@ module Shipit
     test "#perform fetch commits from the API" do
       @job.stubs(:capture!)
       @job.stubs(:capture)
-      @commands = stub(:commands)
+      @commands = stub(commands: nil)
       Commands.expects(:for).with(@deploy).returns(@commands)
 
       @commands.expects(:fetched?).once.returns(FakeSuccessfulCommand.new)
@@ -141,7 +141,7 @@ module Shipit
 
     test "records stack support for rollbacks and fetching deployed revision" do
       @job.stubs(:capture!)
-      @commands = stub(:commands)
+      @commands = stub(commands: nil)
       @commands.stubs(:fetched?).returns([])
       @commands.stubs(:fetch).returns([])
       @commands.stubs(:clone).returns([])

--- a/test/models/shipit/stack_provisioning_handler_test.rb
+++ b/test/models/shipit/stack_provisioning_handler_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Shipit
+  class StackProvisioningHandlerTest < ActiveSupport::TestCase
+    teardown do
+      Shipit::ProvisioningHandler.reset!
+    end
+
+    test "uses default handler when no handler is registered for the stack's repository" do
+      stack = shipit_stacks(:shipit)
+
+      assert_equal Shipit::ProvisioningHandler::Base, Shipit::ProvisioningHandler.for_stack(stack)
+    end
+
+    test "allows registration of a default handler" do
+      mock_handler = mock("Mock Provisioning Handler")
+
+      Shipit::ProvisioningHandler.register(:default, mock_handler)
+
+      assert_equal mock_handler, Shipit::ProvisioningHandler.for_stack(shipit_stacks(:shipit))
+    end
+
+    test "registers handlers at the repository level" do
+      stack = shipit_stacks(:shipit)
+      mock_handler = mock("Mock Provisioning Handler")
+
+      Shipit::ProvisioningHandler.register(stack.github_repo_name, mock_handler)
+
+      assert_equal mock_handler, Shipit::ProvisioningHandler.for_stack(stack)
+
+      stack = shipit_stacks(:shipit_canaries)
+      assert_equal mock_handler, Shipit::ProvisioningHandler.for_stack(stack)
+    end
+
+    test "handlers are called during provisioning" do
+      stack = shipit_stacks(:shipit)
+      stack.update(
+        provision_status: :pending_provision,
+        auto_provisioned: true
+      )
+      mock_handler = mock("Mock Provisioning Handler")
+      mock_handler.expects(:new).with(stack).returns(mock_handler)
+      Shipit::ProvisioningHandler.register(stack.github_repo_name, mock_handler)
+
+      mock_handler.expects(:up)
+
+      assert stack.provision!, "stack should have provisioned."
+    end
+
+    test "handlers are called during deprovisioning" do
+      stack = shipit_stacks(:shipit)
+      stack.update(
+        provision_status: :pending_deprovision,
+        auto_provisioned: true
+      )
+      mock_handler = mock("Mock Provisioning Handler")
+      mock_handler.expects(:new).with(stack).returns(mock_handler)
+      Shipit::ProvisioningHandler.register(stack.github_repo_name, mock_handler)
+
+      mock_handler.expects(:down)
+
+      assert stack.deprovision!, "stack should have deprovisioned."
+    end
+  end
+end

--- a/test/models/shipit/stack_provisioning_handler_test.rb
+++ b/test/models/shipit/stack_provisioning_handler_test.rb
@@ -37,7 +37,7 @@ module Shipit
     test "handlers are called during provisioning" do
       stack = shipit_stacks(:shipit)
       stack.update(
-        provision_status: :pending_provision,
+        provision_status: :deprovisioned,
         auto_provisioned: true
       )
       mock_handler = mock("Mock Provisioning Handler")
@@ -52,7 +52,7 @@ module Shipit
     test "handlers are called during deprovisioning" do
       stack = shipit_stacks(:shipit)
       stack.update(
-        provision_status: :pending_deprovision,
+        provision_status: :provisioned,
         auto_provisioned: true
       )
       mock_handler = mock("Mock Provisioning Handler")

--- a/test/models/shipit/stacks_provision_status_test.rb
+++ b/test/models/shipit/stacks_provision_status_test.rb
@@ -1,112 +1,71 @@
 # frozen_string_literal: true
 
-# frozen_string_literal: true
 require 'test_helper'
 
 module Shipit
   class StackProvisionStatusTest < ActiveSupport::TestCase
-    test "stacks default to not_provisioned state" do
+    test "stacks default to deprovisioned state" do
       stack = Shipit::Stack.new
 
-      assert_equal 'not_provisioned', stack.provision_status
+      assert_equal 'deprovisioned', stack.provision_status
     end
 
     test "non-review stacks don't transition" do
       stack = Shipit::Stack.new
-      stack.schedule_provision
+      stack.provision
 
-      assert_equal 'not_provisioned', stack.provision_status
+      assert_equal 'deprovisioned', stack.provision_status
     end
 
-    test "review stacks that have yet to be provisioned can be scheduled for provisioning" do
-      stack = review_stack(provision_status: :not_provisioned)
-
-      stack.schedule_provision
-
-      assert_equal 'pending_provision', stack.provision_status
-    end
-
-    test "review stacks that have been scheduled for provisioning can be provisioned" do
-      stack = review_stack(provision_status: :pending_provision)
+    test "review stacks that are deprovisioned can be provisioned" do
+      stack = review_stack(provision_status: :deprovisioned)
 
       stack.provision
 
       assert_equal 'provisioning', stack.provision_status
     end
 
-    test "review stacks that have been provisioning can be marked as provisioned" do
+    test "review stacks that are provisioning can succeed" do
       stack = review_stack(provision_status: :provisioning)
 
-      stack.provisioned
+      stack.provision_success
 
       assert_equal 'provisioned', stack.provision_status
     end
 
-    test "review stacks which are provisioning can fail to provision" do
+    test "review stacks that are provisioning can fail" do
       stack = review_stack(provision_status: :provisioning)
 
-      stack.fail_provisioning
-
-      assert_equal 'provisioning_error', stack.provision_status
-    end
-
-    test "review stacks that have previously failed to provision can be scheduled for provisioning" do
-      stack = review_stack(provision_status: :provisioning_error)
-
-      stack.schedule_provision
-
-      assert_equal 'pending_provision', stack.provision_status
-    end
-
-    test "review stacks that have been provisioned can be scheduled for deprovisioning" do
-      stack = review_stack(provision_status: :provisioned)
-
-      stack.schedule_deprovision
-
-      assert_equal 'pending_deprovision', stack.provision_status
-    end
-
-    test "review stacks that have been scheduled for deprovisioning can be deprovisioned" do
-      stack = review_stack(provision_status: :pending_deprovision)
-
-      stack.deprovision
-
-      assert_equal 'deprovisioning', stack.provision_status
-    end
-
-    test "review stacks that have been deprovisioning can be marked as deprovisioned" do
-      stack = review_stack(provision_status: :deprovisioning)
-
-      stack.deprovisioned
+      stack.provision_failure
 
       assert_equal 'deprovisioned', stack.provision_status
     end
 
-    test "review stacks that have been deprovisioning can fail deprovisioning" do
+    test "review stacks are provisioned can be deprovisioned" do
+      stack = review_stack(provision_status: :provisioned)
+
+      stack.deprovision
+
+      assert 'deprovisioning', stack.provision_status
+    end
+
+    test "review stacks that are deprovisioning can succeed" do
       stack = review_stack(provision_status: :deprovisioning)
 
-      stack.fail_deprovisioning
+      stack.deprovision_success
 
-      assert_equal 'deprovisioning_error', stack.provision_status
+      assert_equal 'deprovisioned', stack.provision_status
     end
 
-    test "review stacks that have failed to deprovisioncan be scheduled for deprovisioning" do
-      stack = review_stack(provision_status: :deprovisioning_error)
+    test "review stacks that are deprovisioning can fail" do
+      stack = review_stack(provision_status: :deprovisioning)
 
-      stack.schedule_deprovision
+      stack.deprovision_failure
 
-      assert_equal 'pending_deprovision', stack.provision_status
+      assert_equal 'provisioned', stack.provision_status
     end
 
-    test "review stacks that have been deprovisioned can be scheduled for provisioning" do
-      stack = review_stack(provision_status: :deprovisioned)
-
-      stack.schedule_provision
-
-      assert_equal 'pending_provision', stack.provision_status
-    end
-
-    def review_stack(provision_status: :not_provisioned)
+    def review_stack(provision_status: :deprovisioned)
       stack = shipit_stacks(:shipit)
       stack.auto_provisioned = true
       stack.provision_status = provision_status


### PR DESCRIPTION
In order to make the Review Stack concept more widely applicable, and
therefore ready for integration upstream, we want to make the
provisioning / deprovisioning of Review Stacks more general and
extensible.

The idea here is that the host application could supply its own
(de)provisioning routines - either per-repository, or as a global
default - which the stack will use when the appropriate transition
event occurs.

For example, imagine a repository which deploys to a Kubernetes
cluster. The host application could register a Kubernetes provisioning
handler to take care of creating / destroying kubernetes resources for
a stack:

- Define a provisioning Handler

```ruby
class KubernetesProvisioningHandler < Shipit::ProvisioningHandler::Base
  def up
    # allocate a namespace, copy resources, etc
  end

  def down
    # delete the namespace, etc.
  end
end
```

- Register a default provisioning handler - IE how repositories which
don't explicitly define a provisoining handler will be provisioned:

```ruby
Shipit::ProvisioningHandler.register(:default, KubernetesProvisioningHandler)
```

- Or, define a provisionng handler for a specific repository:

```ruby
Shipit::ProvisioningHandler.register('powerhome/nitro-web', KubernetesProvisioningHandler)
```

A default, no-op provisioning handler is provided when neither a
repository level, nor host-application-default provisioning handler is
provided.
