### PR TITLE
Allow provisioning handler to be configured via shipit.yml

### DIFF
--- a/app/models/shipit/deploy_spec.rb
+++ b/app/models/shipit/deploy_spec.rb
@@ -104,6 +104,10 @@ module Shipit
       Duration.parse(config('deploy', 'interval') { 0 })
     end
 
+    def provisioning_handler_name
+      config('provision', 'handler_name')
+    end
+
     def deploy_steps
       around_steps('deploy') do
         config('deploy', 'override') { discover_deploy_steps }

--- a/app/models/shipit/deploy_spec/file_system.rb
+++ b/app/models/shipit/deploy_spec/file_system.rb
@@ -63,6 +63,7 @@ module Shipit
             'delay' => release_status_delay,
           },
           'dependencies' => { 'override' => dependencies_steps },
+          'provision' => { 'handler_name' => provisioning_handler_name },
           'deploy' => {
             'override' => deploy_steps,
             'variables' => deploy_variables.map(&:to_h),

--- a/app/models/shipit/provisioning_handler.rb
+++ b/app/models/shipit/provisioning_handler.rb
@@ -2,8 +2,6 @@
 
 module Shipit
   module ProvisioningHandler
-    NoRegisteredHandlerError = Class.new(StandardError)
-
     class << self
       def registry
         @registry ||= reset_registry!
@@ -19,13 +17,7 @@ module Shipit
 
       def fetch(name)
         registry.fetch(name) do
-          if name.present?
-            raise(
-              NoRegisteredHandlerError,
-              "Failed to find a provisioning handler named '#{name}' in the ProvisioningHandler registry." \
-              "Have you registered it via Provisioning::Handler.register?"
-            )
-          end
+          return ProvisioningHandler::UnregisteredProvisioningHandler if name.present?
 
           default
         end

--- a/app/models/shipit/provisioning_handler.rb
+++ b/app/models/shipit/provisioning_handler.rb
@@ -2,6 +2,8 @@
 
 module Shipit
   module ProvisioningHandler
+    NoRegisteredHandlerError = Class.new(StandardError)
+
     class << self
       def registry
         @registry ||= reset_registry!
@@ -18,10 +20,10 @@ module Shipit
       def fetch(name)
         registry.fetch(name) do
           if name.present?
-            Rails.logger.debug(
-              "Failed to find a provisining handler named '#{name}' in the ProvisioningHandler registry." \
-              "Have you registered it via Provisioning::Handler.register?" \
-              "Using the default provisioner '#{default}'."
+            raise(
+              NoRegisteredHandlerError,
+              "Failed to find a provisioning handler named '#{name}' in the ProvisioningHandler registry." \
+              "Have you registered it via Provisioning::Handler.register?"
             )
           end
 

--- a/app/models/shipit/provisioning_handler.rb
+++ b/app/models/shipit/provisioning_handler.rb
@@ -16,7 +16,11 @@ module Shipit
       end
 
       def for_stack(stack)
-        handlers[stack.github_repo_name] || handlers[:default] || ProvisioningHandler::Base
+        handlers[stack.github_repo_name] || default
+      end
+
+      def default
+        handlers[:default] || ProvisioningHandler::Base
       end
     end
   end

--- a/app/models/shipit/provisioning_handler/unregistered_provisioning_handler.rb
+++ b/app/models/shipit/provisioning_handler/unregistered_provisioning_handler.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Shipit
+  module ProvisioningHandler
+    class UnregisteredProvisioningHandler < Shipit::ProvisioningHandler::Base
+      def up
+        lock_and_prevent_transition
+      end
+
+      def down
+        lock_and_prevent_transition
+      end
+
+      private
+
+      def lock_and_prevent_transition
+        stack.lock(
+          "Failed to find a provisioning handler named '#{stack.provisioning_handler_name}' in the " \
+          "ProvisioningHandler registry. Have you registered it via Provisioning::Handler.register?",
+          Shipit::AnonymousUser.new
+        )
+        throw(:halt)
+      end
+    end
+  end
+end

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -49,7 +49,8 @@ module Shipit
     end
 
     def provisioner_class
-      ProvisioningHandler.for_stack(self)
+      provisioning_handler_name.presence&.constantize ||
+        ProvisioningHandler.for_stack(self)
     end
 
     module NoDeployedCommit
@@ -144,8 +145,17 @@ module Shipit
     validates :lock_reason, length: { maximum: 4096 }
 
     serialize :cached_deploy_spec, DeploySpec
-    delegate :find_task_definition, :supports_rollback?, :release_status?, :release_status_delay,
-             :release_status_context, :supports_fetch_deployed_revision?, to: :cached_deploy_spec, allow_nil: true
+    delegate(
+      :provisioning_handler_name,
+      :find_task_definition,
+      :release_status?,
+      :release_status_context,
+      :release_status_delay,
+      :supports_fetch_deployed_revision?,
+      :supports_rollback?,
+      to: :cached_deploy_spec,
+      allow_nil: true
+    )
 
     def self.refresh_deployed_revisions
       find_each.select(&:supports_fetch_deployed_revision?).each(&:async_refresh_deployed_revision)

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -49,8 +49,7 @@ module Shipit
     end
 
     def provisioner_class
-      provisioning_handler_name.presence&.constantize ||
-        ProvisioningHandler.for_stack(self)
+      ProvisioningHandler.fetch(provisioning_handler_name)
     end
 
     module NoDeployedCommit

--- a/docs/review_stacks.md
+++ b/docs/review_stacks.md
@@ -75,7 +75,7 @@ ActiveSupport::Reloader.to_prepare do
 end
 ```
 
-A default, no-op provisioning handler - `Shipit::ProvisioningHandler::Base` - is provided. When the name of an unregistered handler is requested from the `Shipit::ProvisioningHandler` a `DEBUG` level message is logged indicating that an unregistered handler was requested and returns the `Shipit::ProvisioningHandler.defailt` handler.
+A default, no-op provisioning handler - `Shipit::ProvisioningHandler::Base` - is provided. When the name of an unregistered handler is requested from the `Shipit::ProvisioningHandler` a `Shipit::ProvisioningHandler::NoRegisteredHandlerError` exception will be raised.
 
 The ProvisioningHandler for a give stack is discovered at runtime using the following order of precedence:
 

--- a/docs/review_stacks.md
+++ b/docs/review_stacks.md
@@ -75,7 +75,7 @@ ActiveSupport::Reloader.to_prepare do
 end
 ```
 
-A default, no-op provisioning handler - `Shipit::ProvisioningHandler::Base` - is provided. When the name of an unregistered handler is requested from the `Shipit::ProvisioningHandler` a `Shipit::ProvisioningHandler::NoRegisteredHandlerError` exception will be raised.
+A default, no-op provisioning handler - `Shipit::ProvisioningHandler::Base` - is provided. When the name of an unregistered handler is requested from the `Shipit::ProvisioningHandler` the `Shipit::ProvisioningHandler::UnregisteredProvisiningHander` is used. Effectively, this prevents transitions of the provisioning state machine and locks the Review Stack indicating that an attempt to provision the Review Stack instance was made, but can't be completed until the Review Stack's Provisioning Handler is registered.
 
 The ProvisioningHandler for a give stack is discovered at runtime using the following order of precedence:
 

--- a/docs/review_stacks.md
+++ b/docs/review_stacks.md
@@ -64,9 +64,9 @@ deploy:
 
 A default, no-op provisioning handler is provided when neither a repository level, nor host-application-default provisioning handler is provided.
 
-The Provisioner for a give stack is discovered at runtime using the following order of precedence:
+The Provisioner for a given stack is discovered at runtime using the following order of precedence:
 
-1. shipit.yml - `hanler_name:` value
+1. shipit.yml - `handler_name:` value
 1. repository name - `Shipit::ProvisioningHandler.register(<stack's github_repo_name>, ...)`
 1. default override - `Shipit::ProvisioningHandler.register(:default, ...)`
 1. no-op default - `ProvisioningHandler::Base`

--- a/docs/review_stacks.md
+++ b/docs/review_stacks.md
@@ -20,15 +20,16 @@ shipit-engine support three distinct behaviors for determining which Pull Reques
 1. "Allow With Label" - when creating or updating a Pull Request, the user must add a label matching the `Shipit::Repository`'s "provisioning_label" attribute in order for shipit-engine to dynamically create/manage a Review Stack - an opt-in strategy.
 1. "Prevent With Label" - when creating or updating a Pull Request, the user must add a label matching the `Shipit::Repository`'s "provisoining_label" attribute in order to **prevent** shipit-engine from dynamically creating/managing a Review Stack - an opt-out strategy.
 
-# Provisioning and deprovisioning Review Stack environments
+# Provisioning and deprovisioning Review Stack instances
 
-Review Stacks will need an environment into which they are deployed. For some this might be a Heroku instance, for others it might be a Kubernetes namespace, etc. shipit-engine allows the host application to define `ProvisioningHandler`s to define how Review Stacks should provisoin/deprovision their environments.
+Review Stacks will need an instance into which they are deployed. For some this might be a Heroku instance, for others it might be a Kubernetes namespace, etc. shipit-engine allows the host application to define `ProvisioningHandler`s to define how Review Stacks should provisoing/deprovision their instances.
 
-For example, imagine a repository which deploys to a Kubernetes cluster. The host application could register a Kubernetes provisioning handler to take care of creating / destroying kubernetes resources for a stack:
+For example, imagine a repository which deploys to a Kubernetes cluster. The host application could register a Kubernetes provisioning handler to take care of setting-up and tearing-down Kubernetes resources for a stack:
 
-Define a provisioning Handler
+Define a provisioning Handler:
 
 ```ruby
+# <path-to-host-application>/app/provisioning_handlers/kubernetes_provisioning_handler.rb
 class KubernetesProvisioningHandler < Shipit::ProvisioningHandler::Base
   def up
     # allocate a namespace, copy resources, etc
@@ -40,21 +41,19 @@ class KubernetesProvisioningHandler < Shipit::ProvisioningHandler::Base
 end
 ```
 
-Register a default provisioning handler - IE how repositories which don't explicitly define a provisoining handler will be provisioned:
+The host application **MUST** `#register` - whitelist - the custom ProvisioningHandler in the `Shipit::ProvisioningHandler` registry. This will  most likely happen as part of a shipit-engine initialization routine in the host application. For example:
 
 ```ruby
-Shipit::ProvisioningHandler.register(:default, KubernetesProvisioningHandler)
+# <path-to-host-application>/config/initializers/shipit.rb
+ActiveSupport::Reloader.to_prepare do
+  ...
+  Shipit::ProvisioningHandler.register(KubernetesProvisioningHandler)
+end
 ```
-
-Or, define a provisionng handler for a specific repository:
-
-```ruby
-Shipit::ProvisioningHandler.register('powerhome/nitro-web', KubernetesProvisioningHandler)
-```
-
-Repository specific `ProvisioningHandler`s can also be configured in the project's `shipit.yml` by supplying the name of the provisioning handler supplied by the host application. For example:
+The custom `KubernetesProvisioningHandler` can the  be used in a project's `shipit.yml`:
 
 ```yaml
+# <path-to-managed-appliction>/shipit.yml
 provision:
   handler_name: KubernetesProvisioningHandler
 
@@ -62,11 +61,24 @@ deploy:
   override: <deployment-script>
 ```
 
-A default, no-op provisioning handler is provided when neither a repository level, nor host-application-default provisioning handler is provided.
+Now all Review Stacks for this repository will use the `KubernetesProvisioningHandler` to (de)provision their instances.
 
-The Provisioner for a given stack is discovered at runtime using the following order of precedence:
+## Default `ProvisioningHandler`s
+
+Register a host-application-wide default provisioning handler - IE how repositories which don't explicitly define a provisoining handler will be provisioned:
+
+```ruby
+# <path-to-host-application>/config/initializers/shipit.rb
+ActiveSupport::Reloader.to_prepare do
+  ...
+  Shipit::ProvisioningHandler.register(KubernetesProvisioningHandler)
+end
+```
+
+A default, no-op provisioning handler - `Shipit::ProvisioningHandler::Base` - is provided. When the name of an unregistered handler is requested from the `Shipit::ProvisioningHandler` a `DEBUG` level message is logged indicating that an unregistered handler was requested and returns the `Shipit::ProvisioningHandler.defailt` handler.
+
+The ProvisioningHandler for a give stack is discovered at runtime using the following order of precedence:
 
 1. shipit.yml - `handler_name:` value
-1. repository name - `Shipit::ProvisioningHandler.register(<stack's github_repo_name>, ...)`
-1. default override - `Shipit::ProvisioningHandler.register(:default, ...)`
+1. Host-application-specific default override - `Shipit::ProvisioningHandler.default = ...`
 1. no-op default - `ProvisioningHandler::Base`

--- a/docs/review_stacks.md
+++ b/docs/review_stacks.md
@@ -1,0 +1,72 @@
+# Review Stacks
+
+A Review Stack is a dynamically managed stack whose lifecycle is tied to a Github Pull Request.
+
+# Enabling Review Stacks
+
+Review stacks can be enabled via the shipit-engine Repository UI.
+
+1. Visit the shipit-engine Repository UI - `https://host-application/repositories`
+1. Click on the project's repository
+1. Check "Dynamically provision stacks for Pull Requests?"
+1. Select the "Provisioning Behavior" appropriate for your project - most likely "Allow All"
+1. Click "Save"
+
+# Configuring Review Stack behavior
+
+shipit-engine support three distinct behaviors for determining which Pull Requests should be considered for Review Stack creation.
+
+1. "Allow All" - shipit-engine will create a Review Stack for every new Pull Requests.
+1. "Allow With Label" - when creating or updating a Pull Request, the user must add a label matching the `Shipit::Repository`'s "provisioning_label" attribute in order for shipit-engine to dynamically create/manage a Review Stack - an opt-in strategy.
+1. "Prevent With Label" - when creating or updating a Pull Request, the user must add a label matching the `Shipit::Repository`'s "provisoining_label" attribute in order to **prevent** shipit-engine from dynamically creating/managing a Review Stack - an opt-out strategy.
+
+# Provisioning and deprovisioning Review Stack environments
+
+Review Stacks will need an environment into which they are deployed. For some this might be a Heroku instance, for others it might be a Kubernetes namespace, etc. shipit-engine allows the host application to define `ProvisioningHandler`s to define how Review Stacks should provisoin/deprovision their environments.
+
+For example, imagine a repository which deploys to a Kubernetes cluster. The host application could register a Kubernetes provisioning handler to take care of creating / destroying kubernetes resources for a stack:
+
+Define a provisioning Handler
+
+```ruby
+class KubernetesProvisioningHandler < Shipit::ProvisioningHandler::Base
+  def up
+    # allocate a namespace, copy resources, etc
+  end
+
+  def down
+    # delete the namespace, etc.
+  end
+end
+```
+
+Register a default provisioning handler - IE how repositories which don't explicitly define a provisoining handler will be provisioned:
+
+```ruby
+Shipit::ProvisioningHandler.register(:default, KubernetesProvisioningHandler)
+```
+
+Or, define a provisionng handler for a specific repository:
+
+```ruby
+Shipit::ProvisioningHandler.register('powerhome/nitro-web', KubernetesProvisioningHandler)
+```
+
+Repository specific `ProvisioningHandler`s can also be configured in the project's `shipit.yml` by supplying the name of the provisioning handler supplied by the host application. For example:
+
+```yaml
+provision:
+  handler_name: KubernetesProvisioningHandler
+
+deploy:
+  override: <deployment-script>
+```
+
+A default, no-op provisioning handler is provided when neither a repository level, nor host-application-default provisioning handler is provided.
+
+The Provisioner for a give stack is discovered at runtime using the following order of precedence:
+
+1. shipit.yml - `hanler_name:` value
+1. repository name - `Shipit::ProvisioningHandler.register(<stack's github_repo_name>, ...)`
+1. default override - `Shipit::ProvisioningHandler.register(:default, ...)`
+1. no-op default - `ProvisioningHandler::Base`

--- a/test/models/deploy_spec_test.rb
+++ b/test/models/deploy_spec_test.rb
@@ -106,6 +106,12 @@ module Shipit
       refute @spec.bundle_install.last.include?('--frozen')
     end
 
+    test "#provisioning_handler returns `provision.handler` if present" do
+      @spec.stubs(:load_config).returns('provision' => { 'handler_name' => 'ExpectedProvisioningHandler' })
+
+      assert_equal "ExpectedProvisioningHandler", @spec.provisioning_handler_name
+    end
+
     test '#deploy_steps returns `deploy.override` if present' do
       @spec.stubs(:load_config).returns('deploy' => { 'override' => %w(foo bar baz) })
       assert_equal %w(foo bar baz), @spec.deploy_steps
@@ -364,6 +370,9 @@ module Shipit
         },
         'dependencies' => { 'override' => [] },
         'plugins' => {},
+        'provision' => {
+          'handler_name' => nil,
+        },
         'deploy' => {
           'override' => nil,
           'variables' => [],

--- a/test/models/shipit/provisioning_handler/unregistered_provisioning_handler_test.rb
+++ b/test/models/shipit/provisioning_handler/unregistered_provisioning_handler_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Shipit
+  module ProvisioningHandler
+    class UnregisteredProvisioningHandlerTest < ActiveSupport::TestCase
+      test "#up stops transitions" do
+        stack = shipit_stacks(:shipit)
+        stack.update(
+          provision_status: :deprovisioned,
+          auto_provisioned: true
+        )
+
+        assert_throws :halt do
+          UnregisteredProvisioningHandler.new(stack).up
+        end
+      end
+
+      test "#up locks the stack" do
+        stack = shipit_stacks(:shipit)
+        stack.update(
+          provision_status: :deprovisioned,
+          auto_provisioned: true
+        )
+
+        assert_changes -> { stack.locked? }, from: false, to: true do
+          catch :halt do
+            UnregisteredProvisioningHandler.new(stack).up
+          end
+        end
+      end
+
+      test "#down stops transitions" do
+        stack = shipit_stacks(:shipit)
+        stack.update(
+          provision_status: :deprovisioned,
+          auto_provisioned: true
+        )
+
+        assert_throws :halt do
+          UnregisteredProvisioningHandler.new(stack).down
+        end
+      end
+
+      test "#down prevents transitions" do
+        stack = shipit_stacks(:shipit)
+        stack.update(
+          provision_status: :deprovisioned,
+          auto_provisioned: true
+        )
+
+        assert_changes -> { stack.locked? }, from: false, to: true do
+          catch :halt do
+            UnregisteredProvisioningHandler.new(stack).down
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/models/shipit/stack_provisioning_handler_test.rb
+++ b/test/models/shipit/stack_provisioning_handler_test.rb
@@ -20,12 +20,13 @@ module Shipit
       assert_equal mock_handler, Shipit::ProvisioningHandler.default
     end
 
-    test "an UnregisteredProvisioningHandlerError is raised when an attempt to fetch an unregistered handler is made" do
+    test "UnregisteredProvisioningHandler is returned when an attempt to fetch an unregistered handler is made" do
       unregistered_handler = mock("Mock Provisioning Handler")
 
-      assert_raises Shipit::ProvisioningHandler::NoRegisteredHandlerError do
+      assert_equal(
+        Shipit::ProvisioningHandler::UnregisteredProvisioningHandler,
         Shipit::ProvisioningHandler.fetch(unregistered_handler)
-      end
+      )
     end
 
     test "registers handlers so they become fetchable" do

--- a/test/models/shipit/stack_provisioning_handler_test.rb
+++ b/test/models/shipit/stack_provisioning_handler_test.rb
@@ -5,33 +5,34 @@ require 'test_helper'
 module Shipit
   class StackProvisioningHandlerTest < ActiveSupport::TestCase
     teardown do
-      Shipit::ProvisioningHandler.reset!
+      Shipit::ProvisioningHandler.reset_registry!
     end
 
-    test "uses default handler when no handler is registered for the stack's repository" do
-      stack = shipit_stacks(:shipit)
-
-      assert_equal Shipit::ProvisioningHandler::Base, Shipit::ProvisioningHandler.for_stack(stack)
+    test "uses the no-op handler as default when no default handler is registered" do
+      assert_equal Shipit::ProvisioningHandler::Base, Shipit::ProvisioningHandler.fetch("unregistered-handler")
     end
 
     test "allows registration of a default handler" do
       mock_handler = mock("Mock Provisioning Handler")
 
-      Shipit::ProvisioningHandler.register(:default, mock_handler)
+      Shipit::ProvisioningHandler.default = mock_handler
 
-      assert_equal mock_handler, Shipit::ProvisioningHandler.for_stack(shipit_stacks(:shipit))
+      assert_equal mock_handler, Shipit::ProvisioningHandler.default
     end
 
-    test "registers handlers at the repository level" do
-      stack = shipit_stacks(:shipit)
+    test "the default handler is returned when an attempt to fetch an unregistered handler is made" do
+      default_handler = Shipit::ProvisioningHandler.default
+      unregistered_handler = mock("Mock Provisioning Handler")
+
+      assert_equal default_handler, Shipit::ProvisioningHandler.fetch(unregistered_handler)
+    end
+
+    test "registers handlers so they become fetchable" do
       mock_handler = mock("Mock Provisioning Handler")
 
-      Shipit::ProvisioningHandler.register(stack.github_repo_name, mock_handler)
+      Shipit::ProvisioningHandler.register(mock_handler)
 
-      assert_equal mock_handler, Shipit::ProvisioningHandler.for_stack(stack)
-
-      stack = shipit_stacks(:shipit_canaries)
-      assert_equal mock_handler, Shipit::ProvisioningHandler.for_stack(stack)
+      assert_equal mock_handler, Shipit::ProvisioningHandler.fetch(mock_handler.to_s)
     end
 
     test "handlers are called during provisioning" do
@@ -40,11 +41,9 @@ module Shipit
         provision_status: :deprovisioned,
         auto_provisioned: true
       )
-      mock_handler = mock("Mock Provisioning Handler")
-      mock_handler.expects(:new).with(stack).returns(mock_handler)
-      Shipit::ProvisioningHandler.register(stack.github_repo_name, mock_handler)
+      handler = Shipit::ProvisioningHandler.default
 
-      mock_handler.expects(:up)
+      handler.any_instance.expects(:up)
 
       assert stack.provision!, "stack should have provisioned."
     end
@@ -55,11 +54,9 @@ module Shipit
         provision_status: :provisioned,
         auto_provisioned: true
       )
-      mock_handler = mock("Mock Provisioning Handler")
-      mock_handler.expects(:new).with(stack).returns(mock_handler)
-      Shipit::ProvisioningHandler.register(stack.github_repo_name, mock_handler)
+      handler = Shipit::ProvisioningHandler.default
 
-      mock_handler.expects(:down)
+      handler.any_instance.expects(:down)
 
       assert stack.deprovision!, "stack should have deprovisioned."
     end

--- a/test/models/shipit/stack_provisioning_handler_test.rb
+++ b/test/models/shipit/stack_provisioning_handler_test.rb
@@ -9,7 +9,7 @@ module Shipit
     end
 
     test "uses the no-op handler as default when no default handler is registered" do
-      assert_equal Shipit::ProvisioningHandler::Base, Shipit::ProvisioningHandler.fetch("unregistered-handler")
+      assert_equal Shipit::ProvisioningHandler::Base, Shipit::ProvisioningHandler.default
     end
 
     test "allows registration of a default handler" do
@@ -20,11 +20,12 @@ module Shipit
       assert_equal mock_handler, Shipit::ProvisioningHandler.default
     end
 
-    test "the default handler is returned when an attempt to fetch an unregistered handler is made" do
-      default_handler = Shipit::ProvisioningHandler.default
+    test "an UnregisteredProvisioningHandlerError is raised when an attempt to fetch an unregistered handler is made" do
       unregistered_handler = mock("Mock Provisioning Handler")
 
-      assert_equal default_handler, Shipit::ProvisioningHandler.fetch(unregistered_handler)
+      assert_raises Shipit::ProvisioningHandler::NoRegisteredHandlerError do
+        Shipit::ProvisioningHandler.fetch(unregistered_handler)
+      end
     end
 
     test "registers handlers so they become fetchable" do


### PR DESCRIPTION
Notes
-----

Requires PR #35 to merge before this can be considered for adoption.

References
----------

- https://github.com/powerhome/shipit-engine/pull/35
- https://github.com/powerhome/shipit-engine/pull/35#issuecomment-648125441