### PR TITLE
Awaiting provision stacks should not be deployable

### DIFF
--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -355,7 +355,7 @@ module Shipit
     end
 
     def deployable?
-      !locked? && !active_task?
+      !locked? && !active_task? && !awaiting_provision?
     end
 
     def allows_merges?

--- a/test/models/shipit/stacks_test.rb
+++ b/test/models/shipit/stacks_test.rb
@@ -267,8 +267,9 @@ module Shipit
       end
     end
 
-    test "#deployable? returns true if the stack is not locked and is not deploying" do
+    test "#deployable? returns true if the stack is not locked awaiting provision and is not deploying" do
       @stack.deploys.destroy_all
+      @stack.update!(lock_reason: nil, awaiting_provision: false)
       assert_predicate @stack, :deployable?
     end
 
@@ -279,6 +280,11 @@ module Shipit
 
     test "#deployable? returns false if the stack is deploying" do
       @stack.trigger_deploy(shipit_commits(:third), AnonymousUser.new)
+      refute_predicate @stack, :deployable?
+    end
+
+    test "#deployable? returns false if the stack is awaiting provisioning" do
+      @stack.update!(lock_reason: nil, awaiting_provision: true)
       refute_predicate @stack, :deployable?
     end
 


### PR DESCRIPTION
We need to prevent deployments from happening for review stacks that are still in the queue waiting for resources to be provisioned.