### PR TITLE
Add pull_request serializer

### DIFF
--- a/app/serializers/shipit/pull_request_serializer.rb
+++ b/app/serializers/shipit/pull_request_serializer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Shipit
+  class PullRequestSerializer < ActiveModel::Serializer
+    include GithubUrlHelper
+    include ConditionalAttributes
+
+    has_one :user
+    has_many :assignees, serializer: UserSerializer
+
+    attributes :id, :number, :title, :github_id, :additions, :deletions, :state, :html_url
+
+    def html_url
+      github_pull_request_url(object) if object.stack.present?
+    end
+  end
+end

--- a/test/serializers/shipit/pull_request_serializer_test.rb
+++ b/test/serializers/shipit/pull_request_serializer_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Shipit
+  class PulLRequestSerializerTest < ActiveSupport::TestCase
+    test "structure" do
+      pull_request = shipit_pull_requests(:review_stack_review)
+
+      serialized = serializer.new(pull_request).as_json
+
+      assert_includes serialized.keys, :id
+      assert_includes serialized.keys, :number
+      assert_includes serialized.keys, :title
+      assert_includes serialized.keys, :github_id
+      assert_includes serialized.keys, :additions
+      assert_includes serialized.keys, :deletions
+      assert_includes serialized.keys, :state
+      assert_includes serialized.keys, :html_url
+      assert_includes serialized.keys, :user
+      assert_includes serialized.keys, :assignees
+    end
+
+    def serializer
+      Shipit::PullRequestSerializer
+    end
+  end
+end


### PR DESCRIPTION
The default serialization of `Shipit::PullRequest` objects omits the `#assignee` collection of `Shipit::User`s. Our host application depends on these to notify a Github PullRequest's assignees of changes to the Pull Request. 

This adds a proper serializer class for the newly added `Shipit::PullRequest` object which will produce the correct payload when generating `Shipit::Hook`s.