### PR TITLE
Add head commit to pull requests

### DIFF
--- a/app/models/shipit/pull_request.rb
+++ b/app/models/shipit/pull_request.rb
@@ -6,6 +6,7 @@ module Shipit
 
     belongs_to :stack
     belongs_to :user
+    belongs_to :head, class_name: 'Shipit::Commit', optional: true
 
     has_many :pull_request_assignments
     has_many :assignees, class_name: :User, through: :pull_request_assignments, source: :user
@@ -13,23 +14,33 @@ module Shipit
     has_many :pull_request_labels
     has_many :labels, through: :pull_request_labels
 
-    def self.from_github(github_pull_request)
-      new(attributes_from_github(github_pull_request))
+    def github_pull_request=(github_pull_request)
+      self.github_id = github_pull_request.id
+      self.number = github_pull_request.number
+      self.api_url = github_pull_request.url
+      self.title = github_pull_request.title
+      self.state = github_pull_request.state
+      self.additions = github_pull_request.additions
+      self.deletions = github_pull_request.deletions
+      self.user = User.find_or_create_by_login!(github_pull_request.user.login)
+      self.assignees = github_pull_request.assignees.map do |github_user|
+        User.find_or_create_by_login!(github_user.login)
+      end
+      self.labels = github_pull_request.labels.map do |github_label|
+        Label.find_or_create_from_github!(github_label)
+      end
+      self.head = find_or_create_commit_from_github_by_sha!(github_pull_request.head.sha)
     end
 
-    def self.attributes_from_github(github_pull_request)
-      {
-        github_id: github_pull_request.id,
-        number: github_pull_request.number,
-        api_url: github_pull_request.url,
-        title: github_pull_request.title,
-        state: github_pull_request.state,
-        additions: github_pull_request.additions,
-        deletions: github_pull_request.deletions,
-        user: User.find_or_create_by_login!(github_pull_request.user.login),
-        assignees: github_pull_request.assignees.map { |github_user| User.find_or_create_by_login!(github_user.login) },
-        labels: github_pull_request.labels.map { |github_label| Label.find_or_create_from_github!(github_label) },
-      }
+    def find_or_create_commit_from_github_by_sha!(sha)
+      if commit = stack.commits.by_sha(sha)
+        commit
+      else
+        github_commit = Shipit.github.api.commit(stack.github_repo_name, sha)
+        stack.commits.create_from_github!(github_commit)
+      end
+    rescue ActiveRecord::RecordNotUnique
+      retry
     end
   end
 end

--- a/app/models/shipit/webhooks/handlers/pull_request/assigned_handler.rb
+++ b/app/models/shipit/webhooks/handlers/pull_request/assigned_handler.rb
@@ -16,6 +16,10 @@ module Shipit
               requires :state, String
               requires :additions, Integer
               requires :deletions, Integer
+              requires :head do
+                requires :sha, String
+                requires :ref, String
+              end
               requires :user do
                 requires :login, String
               end
@@ -37,7 +41,7 @@ module Shipit
           def process
             return unless respond_to_assignee_change?
 
-            pull_request.update(pull_request_attributes) if pull_request.present?
+            pull_request.update(github_pull_request: params.pull_request) if pull_request.present?
           end
 
           private
@@ -62,10 +66,6 @@ module Shipit
 
           def repository
             Shipit::Repository.from_github_repo_name(params.repository.full_name) || Shipit::NullRepository.new
-          end
-
-          def pull_request_attributes
-            Shipit::PullRequest.attributes_from_github(params.pull_request)
           end
         end
       end

--- a/app/models/shipit/webhooks/handlers/pull_request/closed_handler.rb
+++ b/app/models/shipit/webhooks/handlers/pull_request/closed_handler.rb
@@ -16,6 +16,10 @@ module Shipit
               requires :state, String
               requires :additions, Integer
               requires :deletions, Integer
+              requires :head do
+                requires :sha, String
+                requires :ref, String
+              end
               requires :user do
                 requires :login, String
               end

--- a/app/models/shipit/webhooks/handlers/pull_request/edited_handler.rb
+++ b/app/models/shipit/webhooks/handlers/pull_request/edited_handler.rb
@@ -16,6 +16,10 @@ module Shipit
               requires :state, String
               requires :additions, Integer
               requires :deletions, Integer
+              requires :head do
+                requires :sha, String
+                requires :ref, String
+              end
               requires :user do
                 requires :login, String
               end
@@ -37,7 +41,7 @@ module Shipit
           def process
             return unless respond_to_pull_request_edited?
 
-            pull_request.update_attributes(pull_request_attributes) if pull_request.present?
+            pull_request.update(github_pull_request: params.pull_request) if pull_request.present?
           end
 
           private
@@ -58,10 +62,6 @@ module Shipit
 
           def repository
             Shipit::Repository.from_github_repo_name(params.repository.full_name) || Shipit::NullRepository.new
-          end
-
-          def pull_request_attributes
-            Shipit::PullRequest.attributes_from_github(params.pull_request)
           end
 
           def respond_to_pull_request_edited?

--- a/app/models/shipit/webhooks/handlers/pull_request/label_capturing_handler.rb
+++ b/app/models/shipit/webhooks/handlers/pull_request/label_capturing_handler.rb
@@ -16,6 +16,10 @@ module Shipit
               requires :state, String
               requires :additions, Integer
               requires :deletions, Integer
+              requires :head do
+                requires :sha, String
+                requires :ref, String
+              end
               requires :user do
                 requires :login, String
               end

--- a/app/models/shipit/webhooks/handlers/pull_request/labeled_handler.rb
+++ b/app/models/shipit/webhooks/handlers/pull_request/labeled_handler.rb
@@ -16,6 +16,10 @@ module Shipit
               requires :state, String
               requires :additions, Integer
               requires :deletions, Integer
+              requires :head do
+                requires :sha, String
+                requires :ref, String
+              end
               requires :user do
                 requires :login, String
               end

--- a/app/models/shipit/webhooks/handlers/pull_request/opened_handler.rb
+++ b/app/models/shipit/webhooks/handlers/pull_request/opened_handler.rb
@@ -16,6 +16,10 @@ module Shipit
               requires :state, String
               requires :additions, Integer
               requires :deletions, Integer
+              requires :head do
+                requires :sha, String
+                requires :ref, String
+              end
               requires :user do
                 requires :login, String
               end

--- a/app/models/shipit/webhooks/handlers/pull_request/reopened_handler.rb
+++ b/app/models/shipit/webhooks/handlers/pull_request/reopened_handler.rb
@@ -16,6 +16,10 @@ module Shipit
               requires :state, String
               requires :additions, Integer
               requires :deletions, Integer
+              requires :head do
+                requires :sha, String
+                requires :ref, String
+              end
               requires :user do
                 requires :login, String
               end

--- a/app/models/shipit/webhooks/handlers/pull_request/review_stack_adapter.rb
+++ b/app/models/shipit/webhooks/handlers/pull_request/review_stack_adapter.rb
@@ -69,9 +69,12 @@ module Shipit
           end
 
           def create!
-            stack = scope.build(stack_attributes)
-            stack.pull_request = Shipit::PullRequest.from_github(params.pull_request)
-            stack.save!
+            stack = scope.create!(stack_attributes)
+            Shipit::PullRequest.create!(
+              stack: stack,
+              github_pull_request: params.pull_request
+            )
+
             Shipit::ReviewStackProvisioningQueue.add(stack)
 
             @stack = stack
@@ -79,7 +82,7 @@ module Shipit
 
           def stack_attributes
             {
-              branch: params.pull_request["head"]["ref"],
+              branch: params.pull_request.head.ref,
               environment: environment,
               ignore_ci: false,
               continuous_deployment: false,

--- a/app/models/shipit/webhooks/handlers/pull_request/unlabeled_handler.rb
+++ b/app/models/shipit/webhooks/handlers/pull_request/unlabeled_handler.rb
@@ -16,6 +16,10 @@ module Shipit
               requires :state, String
               requires :additions, Integer
               requires :deletions, Integer
+              requires :head do
+                requires :sha, String
+                requires :ref, String
+              end
               requires :user do
                 requires :login, String
               end

--- a/app/serializers/shipit/pull_request_serializer.rb
+++ b/app/serializers/shipit/pull_request_serializer.rb
@@ -6,6 +6,7 @@ module Shipit
     include ConditionalAttributes
 
     has_one :user
+    has_one :head, serializer: ShortCommitSerializer
     has_many :assignees, serializer: UserSerializer
 
     attributes :id, :number, :title, :github_id, :additions, :deletions, :state, :html_url

--- a/db/migrate/20200823172649_add_head_reference_to_pull_requests.rb
+++ b/db/migrate/20200823172649_add_head_reference_to_pull_requests.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddHeadReferenceToPullRequests < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :pull_requests, :head
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_17_120832) do
+ActiveRecord::Schema.define(version: 2020_08_23_172649) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text "permissions", limit: 65535
@@ -219,6 +219,8 @@ ActiveRecord::Schema.define(version: 2020_08_17_120832) do
     t.integer "user_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "head_id"
+    t.index ["head_id"], name: "index_pull_requests_on_head_id"
     t.index ["stack_id", "github_id"], name: "index_pull_requests_on_stack_id_and_github_id", unique: true
     t.index ["stack_id", "number"], name: "index_pull_requests_on_stack_id_and_number", unique: true
     t.index ["stack_id"], name: "index_pull_requests_on_stack_id"

--- a/test/fixtures/shipit/commits.yml
+++ b/test/fixtures/shipit/commits.yml
@@ -390,7 +390,7 @@ check_deploy_spec_first:
 
 deployable_review_stack_commit:
   id: 801
-  sha: 6d9278037b872fd9a6690523e411ecb3aa181355
+  sha: ec26c3e57ca3a959ca5aad62de7213c562f8c821
   message: "lets go"
   stack: review_stack
   author: walrus

--- a/test/fixtures/shipit/pull_requests.yml
+++ b/test/fixtures/shipit/pull_requests.yml
@@ -11,6 +11,7 @@ shipit_review:
 review_stack_review:
   stack: review_stack
   number: 100
+  head_id: 801
   title: Review Stack Pull Request
   github_id: 100110001
   api_url: https://api.github.com/repos/shopify/shipit-engine/pulls/100

--- a/test/models/shipit/pull_request_test.rb
+++ b/test/models/shipit/pull_request_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 module Shipit
   class PullRequestTest < ActiveSupport::TestCase
-    test ".from_github creates a Shipit::PullRequest" do
+    test "github_pull_request= parses into a a Shipit::PullRequest" do
       github_pull_request = resource(
         {
           url: "https://api.github.com/repos/Codertocat/Hello-World/pulls/2",
@@ -14,6 +14,9 @@ module Shipit
           additions: 100,
           deletions: 101,
           title: "Update the README with new information.",
+          head: {
+            sha: "ec26c3e57ca3a959ca5aad62de7213c562f8c821",
+          },
           user: {
             login: "Codertocat",
           },
@@ -29,8 +32,10 @@ module Shipit
           ],
         }
       )
+      stack = shipit_stacks(:review_stack)
+      pull_request = stack.pull_request
 
-      pull_request = PullRequest.from_github(github_pull_request)
+      stack.pull_request.github_pull_request = github_pull_request
 
       assert_equal 279147437, pull_request.github_id
       assert_equal 2, pull_request.number

--- a/test/models/shipit/webhooks/handlers/pull_request/closed_handler_test.rb
+++ b/test/models/shipit/webhooks/handlers/pull_request/closed_handler_test.rb
@@ -155,6 +155,36 @@ module Shipit
             active_tasks.reload
             active_tasks.map(&:complete)
           end
+
+          setup do
+            Shipit.github.api.stubs(:commit)
+              .with("shopify/shipit-engine", "ec26c3e57ca3a959ca5aad62de7213c562f8c821")
+              .returns(
+                resource(
+                  {
+                    sha: "ec26c3e57ca3a959ca5aad62de7213c562f8c821",
+                    commit: {
+                      author: {
+                        name: "Codertocat",
+                        email: "21031067+Codertocat@users.noreply.github.com",
+                        date: "2019-05-15 15:20:30",
+                      },
+                      committer: {
+                        name: "Codertocat",
+                        email: "21031067+Codertocat@users.noreply.github.com",
+                        date: "2019-05-15 15:20:30",
+                      },
+                      message: "Update README.md",
+                    },
+                    stats: {
+                      total: 2,
+                      additions: 1,
+                      deletions: 1,
+                    },
+                  }
+                )
+              )
+          end
         end
       end
     end

--- a/test/models/shipit/webhooks/handlers/pull_request/label_capturing_handler_test.rb
+++ b/test/models/shipit/webhooks/handlers/pull_request/label_capturing_handler_test.rb
@@ -178,6 +178,36 @@ module Shipit
           def environment_for(payload)
             "pr#{payload['number']}"
           end
+
+          setup do
+            Shipit.github.api.stubs(:commit)
+              .with("shopify/shipit-engine", "ec26c3e57ca3a959ca5aad62de7213c562f8c821")
+              .returns(
+                resource(
+                  {
+                    sha: "ec26c3e57ca3a959ca5aad62de7213c562f8c821",
+                    commit: {
+                      author: {
+                        name: "Codertocat",
+                        email: "21031067+Codertocat@users.noreply.github.com",
+                        date: "2019-05-15 15:20:30",
+                      },
+                      committer: {
+                        name: "Codertocat",
+                        email: "21031067+Codertocat@users.noreply.github.com",
+                        date: "2019-05-15 15:20:30",
+                      },
+                      message: "Update README.md",
+                    },
+                    stats: {
+                      total: 2,
+                      additions: 1,
+                      deletions: 1,
+                    },
+                  }
+                )
+              )
+          end
         end
       end
     end

--- a/test/models/shipit/webhooks/handlers/pull_request/labeled_handler_test.rb
+++ b/test/models/shipit/webhooks/handlers/pull_request/labeled_handler_test.rb
@@ -74,7 +74,7 @@ module Shipit
               label: "pull-requests-label"
             )
             payload = payload_parsed(:pull_request_labeled)
-            payload["pull_request"]["labels"] << { "name" => "pull-requests-label" }
+            payload["pull_request"]["labels"] = [{ "name" => "pull-requests-label" }]
 
             LabeledHandler.new(payload).process
 
@@ -294,6 +294,36 @@ module Shipit
 
             assert(stack.awaiting_provision?, "Stack #{stack.environment} should be in the provisioning queue")
             assert(stack.deprovisioned?, "Stack #{stack.environment} should be pending provision")
+          end
+
+          setup do
+            Shipit.github.api.stubs(:commit)
+              .with("shopify/shipit-engine", "ec26c3e57ca3a959ca5aad62de7213c562f8c821")
+              .returns(
+                resource(
+                  {
+                    sha: "ec26c3e57ca3a959ca5aad62de7213c562f8c821",
+                    commit: {
+                      author: {
+                        name: "Codertocat",
+                        email: "21031067+Codertocat@users.noreply.github.com",
+                        date: "2019-05-15 15:20:30",
+                      },
+                      committer: {
+                        name: "Codertocat",
+                        email: "21031067+Codertocat@users.noreply.github.com",
+                        date: "2019-05-15 15:20:30",
+                      },
+                      message: "Update README.md",
+                    },
+                    stats: {
+                      total: 2,
+                      additions: 1,
+                      deletions: 1,
+                    },
+                  }
+                )
+              )
           end
         end
       end

--- a/test/models/shipit/webhooks/handlers/pull_request/reopened_handler_test.rb
+++ b/test/models/shipit/webhooks/handlers/pull_request/reopened_handler_test.rb
@@ -245,6 +245,36 @@ module Shipit
             assert(stack.awaiting_provision?, "Stack #{stack.environment} should be in the provisioning queue")
             assert(stack.deprovisioned?, "Stack #{stack.environment} should be pending provision")
           end
+
+          setup do
+            Shipit.github.api.stubs(:commit)
+              .with("shopify/shipit-engine", "ec26c3e57ca3a959ca5aad62de7213c562f8c821")
+              .returns(
+                resource(
+                  {
+                    sha: "ec26c3e57ca3a959ca5aad62de7213c562f8c821",
+                    commit: {
+                      author: {
+                        name: "Codertocat",
+                        email: "21031067+Codertocat@users.noreply.github.com",
+                        date: "2019-05-15 15:20:30",
+                      },
+                      committer: {
+                        name: "Codertocat",
+                        email: "21031067+Codertocat@users.noreply.github.com",
+                        date: "2019-05-15 15:20:30",
+                      },
+                      message: "Update README.md",
+                    },
+                    stats: {
+                      total: 2,
+                      additions: 1,
+                      deletions: 1,
+                    },
+                  }
+                )
+              )
+          end
         end
       end
     end

--- a/test/models/shipit/webhooks/handlers/pull_request/unlabeled_handler_test.rb
+++ b/test/models/shipit/webhooks/handlers/pull_request/unlabeled_handler_test.rb
@@ -287,6 +287,36 @@ module Shipit
             assert(stack.awaiting_provision?, "Stack #{stack.environment} should be in the provisioning queue")
             assert(stack.deprovisioned?, "Stack #{stack.environment} should be pending provision")
           end
+
+          setup do
+            Shipit.github.api.stubs(:commit)
+              .with("shopify/shipit-engine", "ec26c3e57ca3a959ca5aad62de7213c562f8c821")
+              .returns(
+                resource(
+                  {
+                    sha: "ec26c3e57ca3a959ca5aad62de7213c562f8c821",
+                    commit: {
+                      author: {
+                        name: "Codertocat",
+                        email: "21031067+Codertocat@users.noreply.github.com",
+                        date: "2019-05-15 15:20:30",
+                      },
+                      committer: {
+                        name: "Codertocat",
+                        email: "21031067+Codertocat@users.noreply.github.com",
+                        date: "2019-05-15 15:20:30",
+                      },
+                      message: "Update README.md",
+                    },
+                    stats: {
+                      total: 2,
+                      additions: 1,
+                      deletions: 1,
+                    },
+                  }
+                )
+              )
+          end
         end
       end
     end

--- a/test/serializers/shipit/pull_request_serializer_test.rb
+++ b/test/serializers/shipit/pull_request_serializer_test.rb
@@ -19,6 +19,7 @@ module Shipit
       assert_includes serialized.keys, :html_url
       assert_includes serialized.keys, :user
       assert_includes serialized.keys, :assignees
+      assert_includes serialized.keys, :head
     end
 
     def serializer


### PR DESCRIPTION
We use this in our host application to determine if the currenty
deployment would put the Review Stack in a "current with the head
of the pull request" state - if so, we send notifications to the user
who opened the pull request indicating that their instance is
"ready". This was missed in the original PullRequest implementation.