### PR TITLE
Revert "Merge shopify master into pr review stacks branch"

### DIFF
--- a/app/jobs/shipit/refresh_merge_request_job.rb
+++ b/app/jobs/shipit/refresh_merge_request_job.rb
@@ -4,6 +4,8 @@ module Shipit
     queue_as :default
 
     def perform(merge_request)
+      raise Stack::NotYetSynced if merge_request.stack.commits.blank?
+
       merge_request.refresh!
       ProcessMergeRequestsJob.perform_later(merge_request.stack)
     end

--- a/app/models/shipit/merge_request.rb
+++ b/app/models/shipit/merge_request.rb
@@ -43,6 +43,9 @@ module Shipit
     belongs_to :base_commit, class_name: 'Shipit::Commit', optional: true
     belongs_to :merge_requested_by, class_name: 'Shipit::User', optional: true
     has_one :merge_commit, class_name: 'Shipit::Commit'
+    belongs_to :user, optional: true
+    has_many :merge_request_assignments
+    has_many :assignees, class_name: :User, through: :merge_request_assignments, source: :user
 
     deferred_touch stack: :updated_at
 
@@ -50,11 +53,13 @@ module Shipit
 
     scope :waiting, -> { where(merge_status: WAITING_STATUSES) }
     scope :pending, -> { where(merge_status: 'pending') }
-    scope :to_be_merged, -> { pending.order(merge_requested_at: :asc) }
     scope :queued, -> { where(merge_status: QUEUED_STATUSES).order(merge_requested_at: :asc) }
+    scope :to_be_merged, -> { pending.order(merge_requested_at: :asc) }
 
     after_save :record_merge_status_change
-    after_commit :emit_hooks
+    after_create_commit :emit_create_hooks
+    after_update_commit :emit_update_hooks
+    after_destroy_commit :emit_destroy_hooks
 
     state_machine :merge_status, initial: :fetching do
       state :fetching
@@ -237,6 +242,8 @@ module Shipit
     end
 
     def github_pull_request=(github_pull_request)
+      user = User.find_by(login: github_pull_request.user.login) || Shipit::AnonymousUser.new
+
       self.github_id = github_pull_request.id
       self.api_url = github_pull_request.url
       self.title = github_pull_request.title
@@ -249,6 +256,12 @@ module Shipit
       self.merged_at = github_pull_request.merged_at
       self.base_ref = github_pull_request.base.ref
       self.base_commit = find_or_create_commit_from_github_by_sha!(github_pull_request.base.sha, detached: true)
+      self.user = user
+      self.assignees = find_and_assign_users(github_pull_request.assignees)
+    end
+
+    def find_and_assign_users(pr_assignees)
+      pr_assignees.map { |assignee| User.find_by(login: assignee.login) }.compact
     end
 
     def merge_message
@@ -282,10 +295,31 @@ module Shipit
       @merge_status_changed ||= saved_change_to_attribute?(:merge_status)
     end
 
-    def emit_hooks
+    def emit_destroy_hooks
+      emit_hooks(:destroyed)
+    end
+
+    def emit_create_hooks
+      emit_hooks(:created)
+    end
+
+    def emit_update_hooks
+      emit_hooks(:updated)
+    end
+
+    def emit_hooks(reason)
+      emit_merge_status_event
+      emit_pull_request_event(reason)
+    end
+
+    def emit_merge_status_event
       return unless @merge_status_changed
       @merge_status_changed = nil
       Hook.emit('merge', stack, merge_request: self, status: merge_status, stack: stack)
+    end
+
+    def emit_pull_request_event(reason)
+      Hook.emit('pull_request', stack, pull_request: self, action: reason, stack: stack)
     end
 
     def find_or_create_commit_from_github_by_sha!(sha, attributes)

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -3,6 +3,8 @@ require 'fileutils'
 
 module Shipit
   class Stack < Record
+    NotYetSynced = Class.new(StandardError)
+
     module NoDeployedCommit
       extend self
 
@@ -47,6 +49,8 @@ module Shipit
 
     include DeferredTouch
     deferred_touch repository: :updated_at
+
+    default_scope { preload(:repository) }
 
     default_scope { preload(:repository) }
 

--- a/app/serializers/shipit/commit_serializer.rb
+++ b/app/serializers/shipit/commit_serializer.rb
@@ -7,7 +7,7 @@ module Shipit
     has_one :author
     has_one :committer
 
-    attributes :additions, :deletions, :authored_at, :committed_at, :html_url, :pull_request, :status, :deployed
+    attributes :additions, :deletions, :authored_at, :committed_at, :html_url, :merge_request, :status, :deployed
 
     def deployed
       object.deployed?
@@ -21,7 +21,7 @@ module Shipit
       github_commit_url(object)
     end
 
-    def pull_request
+    def merge_request
       {
         number: object.pull_request_number,
         html_url: github_pull_request_url(object),

--- a/app/serializers/shipit/deploy_serializer.rb
+++ b/app/serializers/shipit/deploy_serializer.rb
@@ -22,11 +22,5 @@ module Shipit
     def type
       :deploy
     end
-
-    def rollback_once_aborted_to
-      return nil unless object.rollback_once_aborted_to
-
-      DeploySerializer.new(object.rollback_once_aborted_to)
-    end
   end
 end

--- a/app/serializers/shipit/merge_request_serializer.rb
+++ b/app/serializers/shipit/merge_request_serializer.rb
@@ -6,6 +6,8 @@ module Shipit
 
     has_one :merge_requested_by
     has_one :head, serializer: ShortCommitSerializer
+    has_one :user
+    has_many :assignees, serializer: UserSerializer
 
     attributes :id, :number, :title, :github_id, :additions, :deletions, :state, :merge_status, :mergeable,
                :merge_requested_at, :rejection_reason, :html_url, :branch, :base_ref

--- a/app/serializers/shipit/stack_serializer.rb
+++ b/app/serializers/shipit/stack_serializer.rb
@@ -6,9 +6,9 @@ module Shipit
     has_one :lock_author
 
     attributes :id, :repo_owner, :repo_name, :environment, :html_url, :url, :tasks_url, :deploy_url,
-      :merge_requests_url, :deploy_spec, :undeployed_commits_count, :is_locked, :lock_reason, :continuous_deployment,
-      :created_at, :updated_at, :locked_since, :last_deployed_at, :branch, :merge_queue_enabled, :is_archived,
-      :archived_since
+      :merge_requests_url, :deploy_spec, :undeployed_commits_count, :is_locked, :lock_reason, :lock_reason_code,
+      :continuous_deployment, :created_at, :updated_at, :locked_since, :last_deployed_at, :branch, :merge_queue_enabled,
+      :is_archived, :archived_since
 
     def url
       api_stack_url(object)

--- a/app/views/shipit/stacks/index.html.erb
+++ b/app/views/shipit/stacks/index.html.erb
@@ -22,7 +22,7 @@
         <li class="stack search-item <%= stack.archived? ? 'archived' : '' %> <%= stack.undeployed_commits? ? 'undeployed' : '' %> <%= @user_stacks.include?(stack.id) ? 'contributor' : 'not-matching' %>" data-search="<%= stack.repo_name %> <%= stack.environment %> <%= stack.deploy_url %>" data-stack-id="<%= stack.id %>">
           <%= link_to stack_path(stack), class: 'commits-path' do %>
             <span class="col"><%= stack.repo_name %></span>
-            <small class="col"><%= stack.environment %></small>
+            <small class="col"><%= stack.environment.capitalize %></small>
             <small class="col"><%= stack.branch %></small>
             <small class="col"><%= stack.deploy_url %></small>
           <% end %>

--- a/app/views/shipit/stacks/show.html.erb
+++ b/app/views/shipit/stacks/show.html.erb
@@ -12,7 +12,7 @@
         <% if params[:force] %>
           <%= link_to t('emergency_mode.disable'), stack_path(@stack) %>
         <% else %>
-          <%= link_to t('emergency_mode.enable'), stack_path(@stack, force: 1, noredirect: 1), title: t('emergency_mode.enable_description') %>
+          <%= link_to t('emergency_mode.enable'), stack_path(@stack, force: 1), title: t('emergency_mode.enable_description') %>
         <% end %>
       </div>
     </header>

--- a/lib/shipit/command.rb
+++ b/lib/shipit/command.rb
@@ -158,7 +158,6 @@ module Shipit
         IO.select([io], nil, nil, 1)
         retry
       end
-    rescue EOFError
     end
 
     def terminate!(&block)

--- a/test/controllers/api/rollback_controller_test.rb
+++ b/test/controllers/api/rollback_controller_test.rb
@@ -106,7 +106,7 @@ module Shipit
         last_deploy.reload
         assert_response :accepted
         refute_predicate last_deploy, :active?
-        assert_json 'rollback_once_aborted_to.revision.sha', @commit.sha
+        assert_json 'rollback_once_aborted_to.until_commit_id', @commit.id
       end
     end
   end

--- a/test/jobs/perform_task_job_test.rb
+++ b/test/jobs/perform_task_job_test.rb
@@ -21,7 +21,7 @@ module Shipit
     test "#perform fetch commits from the API" do
       @job.stubs(:capture!)
       @job.stubs(:capture)
-      @commands = stub
+      @commands = stub(commands: nil)
       Commands.expects(:for).with(@deploy).returns(@commands)
 
       @commands.expects(:fetched?).once.returns(FakeSuccessfulCommand.new)
@@ -141,7 +141,7 @@ module Shipit
 
     test "records stack support for rollbacks and fetching deployed revision" do
       @job.stubs(:capture!)
-      @commands = stub
+      @commands = stub(commands: nil)
       @commands.stubs(:fetched?).returns([])
       @commands.stubs(:fetch).returns([])
       @commands.stubs(:clone).returns([])

--- a/test/jobs/refresh_merge_request_job_test.rb
+++ b/test/jobs/refresh_merge_request_job_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Shipit
+  class RefreshMergeRequestJobTest < ActiveSupport::TestCase
+    test "perform refreshes the pull request" do
+      merge_request = shipit_merge_requests(:shipit_pending)
+      merge_request.expects(:refresh!).once
+
+      job.perform(merge_request)
+    end
+
+    test "En-queues a merge pull request job for the PR's stack" do
+      merge_request = shipit_merge_requests(:shipit_pending)
+      merge_request.stubs(:refresh!)
+
+      assert_enqueued_with(job: ProcessMergeRequestsJob, args: [merge_request.stack]) do
+        job.perform(merge_request)
+      end
+    end
+
+    test "Raises if the merge_request's stack hasn't yet synced commits with Github" do
+      merge_request = shipit_merge_requests(:shipit_pending)
+      merge_request.stubs(:refresh!)
+      merge_request.stack.commits.clear
+
+      assert_raises(Stack::NotYetSynced) do
+        job.perform(merge_request)
+      end
+    end
+
+    def job
+      RefreshMergeRequestJob.new
+    end
+  end
+end

--- a/test/models/merge_request_test.rb
+++ b/test/models/merge_request_test.rb
@@ -67,6 +67,7 @@ module Shipit
 
     test "refresh! pulls state from GitHub" do
       merge_request = shipit_merge_requests(:shipit_fetching)
+      user = shipit_users(:bob)
 
       head_sha = '64b3833d39def7ec65b57b42f496eb27ab4980b6'
       base_sha = 'ba7ab50e02286f7d6c60c1ef75258133dd9ea763'
@@ -88,6 +89,18 @@ module Shipit
             ref:  'default-branch',
             sha: base_sha,
           ),
+          user: stub(
+            id: 1234,
+            login: 'bob',
+            site_admin: false,
+          ),
+          assignees: [
+            stub(
+              id: 1234,
+              login: 'bob',
+              site_admin: false,
+            ),
+          ],
         ),
       )
 
@@ -130,6 +143,8 @@ module Shipit
       assert_predicate merge_request, :mergeable?
       assert_predicate merge_request, :pending?
       assert_equal 'super-branch', merge_request.branch
+      assert_equal user, merge_request.user
+      assert_equal [user], merge_request.assignees
 
       assert_not_nil merge_request.head
       assert_predicate merge_request.head, :detached?
@@ -236,6 +251,16 @@ module Shipit
       assert_json 'status', 'rejected', document: params[:payload]
       assert_json 'merge_request.rejection_reason', 'merge_conflict', document: params[:payload]
       assert_json 'merge_request.number', @pr.number, document: params[:payload]
+    end
+
+    test "changes to pull request emit hooks" do
+      job = assert_enqueued_with(job: EmitEventJob) do
+        @pr.update!(title: "Brand new title")
+      end
+      params = job.arguments.first
+      assert_equal 'pull_request', params[:event]
+      assert_json 'action', 'updated', document: params[:payload]
+      assert_json 'pull_request.title', 'Brand new title', document: params[:payload]
     end
 
     test "#merge! doesnt delete the branch if there are open PRs against it" do


### PR DESCRIPTION
Reverts powerhome/shipit-engine#65

This upstream merge was applied to the working branch as a squash commit. This essentially rewrites upstream history into a single commit and makes our working branch diverge into an un-mergable, conflicted state with the upstream. 

Instead, we plan to re-perform this operation as a proper merge of the upstream changes to retain compatible history.