### PR TITLE
Remove stacks lock_reason_code

### DIFF
--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -43,7 +43,6 @@ module Shipit
     validates_associated :repository
 
     scope :not_archived, -> { where(archived_since: nil) }
-    scope :locked_because, ->(reason_code) { where(lock_reason_code: reason_code) }
 
     include DeferredTouch
     deferred_touch repository: :updated_at
@@ -444,13 +443,13 @@ module Shipit
       lock_reason.present?
     end
 
-    def lock(reason, user, code: nil)
-      params = { lock_reason: reason, lock_reason_code: code, lock_author: user }
+    def lock(reason, user)
+      params = { lock_reason: reason, lock_author: user }
       update!(params)
     end
 
     def unlock
-      update!(lock_reason: nil, lock_reason_code: nil, lock_author: nil, locked_since: nil)
+      update!(lock_reason: nil, lock_author: nil, locked_since: nil)
     end
 
     def archived?
@@ -458,11 +457,11 @@ module Shipit
     end
 
     def archive!(user)
-      update!(archived_since: Time.now, lock_reason: "Archived", lock_reason_code: "ARCHIVED", lock_author: user)
+      update!(archived_since: Time.now, lock_reason: "Archived", lock_author: user)
     end
 
     def unarchive!
-      update!(archived_since: nil, lock_reason: nil, lock_reason_code: nil, lock_author: nil, locked_since: nil)
+      update!(archived_since: nil, lock_reason: nil, lock_author: nil, locked_since: nil)
     end
 
     def to_param

--- a/app/views/shipit/stacks/_banners.html.erb
+++ b/app/views/shipit/stacks/_banners.html.erb
@@ -44,12 +44,6 @@
         <p class="banner__text">
           <%= auto_link emojify(stack.lock_reason) %>
         </p>
-
-        <% if stack.lock_reason_code %>
-          <p class="banner__text">
-            Code: <%= stack.lock_reason_code %>
-          </p>
-        <% end %>
       </div>
     </div>
   </div>

--- a/db/migrate/20200902103708_remove_stacks_lock_reason_code.rb
+++ b/db/migrate/20200902103708_remove_stacks_lock_reason_code.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RemoveStacksLockReasonCode < ActiveRecord::Migration[6.0]
+  def change
+    remove_index :stacks, :lock_reason_code
+    remove_column :stacks, :lock_reason_code, :string
+  end
+end

--- a/test/controllers/stacks_controller_test.rb
+++ b/test/controllers/stacks_controller_test.rb
@@ -170,7 +170,6 @@ module Shipit
       assert @stack.locked?
       assert_equal shipit_users(:walrus), @stack.lock_author
       assert_equal "Archived", @stack.lock_reason
-      assert_equal "ARCHIVED", @stack.lock_reason_code
     end
 
     test "#update allows to dearchive the stack" do
@@ -184,7 +183,6 @@ module Shipit
       refute @stack.locked?
       assert_nil @stack.locked_since
       assert_nil @stack.lock_reason
-      assert_nil @stack.lock_reason_code
       assert_instance_of AnonymousUser, @stack.lock_author
     end
 

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_31_180428) do
+ActiveRecord::Schema.define(version: 2020_09_02_103708) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text "permissions", limit: 65535
@@ -263,13 +263,11 @@ ActiveRecord::Schema.define(version: 2020_08_31_180428) do
     t.datetime "last_deployed_at"
     t.integer "repository_id", null: false
     t.datetime "archived_since"
-    t.string "lock_reason_code"
     t.string "provision_status", default: "deprovisioned", null: false
     t.string "type", default: "Shipit::Stack"
     t.boolean "awaiting_provision", default: false, null: false
     t.index ["archived_since"], name: "index_stacks_on_archived_since"
     t.index ["awaiting_provision"], name: "index_stacks_on_awaiting_provision"
-    t.index ["lock_reason_code"], name: "index_stacks_on_lock_reason_code"
     t.index ["provision_status"], name: "index_stacks_on_provision_status"
     t.index ["repository_id", "environment"], name: "stack_unicity", unique: true
     t.index ["repository_id"], name: "index_stacks_on_repository_id"

--- a/test/models/shipit/stacks_test.rb
+++ b/test/models/shipit/stacks_test.rb
@@ -692,23 +692,12 @@ module Shipit
       assert_equal user, @stack.lock_author
     end
 
-    test "#lock can set a reason code" do
-      reason = "Here comes the walrus"
+    test "#unlock deletes reason and user" do
       user = shipit_users(:walrus)
-      code = "STUFF"
-      @stack.lock(reason, user, code: code)
-      assert @stack.locked?
-      assert_equal code, @stack.lock_reason_code
-      assert_equal [@stack], Shipit::Stack.locked_because(code).all
-    end
-
-    test "#unlock deletes reason, user & reason code" do
-      user = shipit_users(:walrus)
-      @stack.lock("Here comes the walrus", user, code: "STUFF")
+      @stack.lock("Here comes the walrus", user)
       @stack.unlock
       refute @stack.locked?
       assert_nil @stack.lock_reason
-      assert_nil @stack.lock_reason_code
       assert_not_equal user, @stack.lock_author
     end
 


### PR DESCRIPTION
This attribute is no longer used. We originally added this as a means indicate a ReviewStack's in/exclusion in the `Shipit::ReviewStackProvisioningQueue`. We've since removed this in favor of the `Stack#awaiting_provision` flag.