### PR TITLE
Compress review stack feature flag migrations

### DIFF
--- a/db/migrate/20191218185534_add_provision_pr_stacks_flag_to_repositories.rb
+++ b/db/migrate/20191218185534_add_provision_pr_stacks_flag_to_repositories.rb
@@ -1,5 +1,5 @@
 class AddProvisionPrStacksFlagToRepositories < ActiveRecord::Migration[6.0]
   def change
-    add_column :repositories, :provision_pr_stacks, :boolean, default: false
+    add_column :repositories, :review_stacks_enabled, :boolean, default: false
   end
 end

--- a/db/migrate/20200714210043_rename_provision_pr_stacks.rb
+++ b/db/migrate/20200714210043_rename_provision_pr_stacks.rb
@@ -1,5 +1,0 @@
-class RenameProvisionPrStacks < ActiveRecord::Migration[6.0]
-  def change
-    rename_column :repositories, :provision_pr_stacks, :review_stacks_enabled
-  end
-end


### PR DESCRIPTION
We _should_ create this feature toggle column with the appropriate
name from the beginning in the upstream PR.

Missed this one in 9d2ad939
