### PR TITLE
Atomically create Review Stacks and their Pull Requests

### DIFF
--- a/app/models/shipit/webhooks/handlers/pull_request/review_stack_adapter.rb
+++ b/app/models/shipit/webhooks/handlers/pull_request/review_stack_adapter.rb
@@ -69,12 +69,14 @@ module Shipit
           end
 
           def create!
-            stack = scope.create!(stack_attributes)
-            stack
-              .build_pull_request
-              .update!(
-                github_pull_request: params.pull_request
-              )
+            ReviewStack.transaction do
+              stack = scope.create!(stack_attributes)
+              stack
+                .build_pull_request
+                .update!(
+                  github_pull_request: params.pull_request
+                )
+            end
 
             Shipit::ReviewStackProvisioningQueue.add(stack)
 

--- a/test/models/shipit/webhooks/handlers/pull_request/opened_handler_test.rb
+++ b/test/models/shipit/webhooks/handlers/pull_request/opened_handler_test.rb
@@ -23,6 +23,18 @@ module Shipit
             end
           end
 
+          test "does not create a stack when the Pull Request data can be saved" do
+            Shipit::PullRequest
+              .any_instance
+              .expects(:update!)
+              .raises(ActiveRecord::StatementInvalid)
+
+            assert_no_difference -> { Shipit::Stack.count } do
+              OpenedHandler.new(payload_parsed(:pull_request_opened)).process
+            rescue ActiveRecord::StatementInvalid # We expect this to be raised, so it shouldn't fail the test
+            end
+          end
+
           test "creates stacks for repos that are tracked" do
             assert_difference -> { Shipit::Stack.count } do
               OpenedHandler.new(payload_parsed(:pull_request_opened)).process


### PR DESCRIPTION
Last evening we observed a Review Stack was created without a Pull
Request. It is our intent that EVERY Review Stack should have an
associated Pull Request. We suspect that the call to
`PullRequest#update!` failed. Since creating the ReviewStack and
PullRequest are flushed to the database independently, we ended up
with a ReviewStack that was missing its PullRequest. This change
attempts to make the creation of the Review Stack and its Pull Request
atomic - ensuring that any Review Stack that is created will have
captured its Pull Request.