### PR TITLE
Logs time it took to run a command during a deployment

### DIFF
--- a/app/models/shipit/task_execution_strategy/default.rb
+++ b/app/models/shipit/task_execution_strategy/default.rb
@@ -83,16 +83,19 @@ module Shipit
       end
 
       def capture!(command)
+        started_at = Time.now
         command.start do
           @task.ping
           check_for_abort
         end
-        @task.write("$ #{command}\npid: #{command.pid}\n")
+        @task.write("$ #{command}\npid: #{command.pid}\nstarted at: #{started_at}\n")
         @task.pid = command.pid
         command.stream! do |line|
           @task.write(line)
         end
         @task.write("\n")
+        finished_at = Time.now
+        @task.write("pid: #{command.pid}\nfinished at: #{finished_at}\nran in: #{finished_at - started_at} seconds\n")
         command.success?
       end
 


### PR DESCRIPTION
Adds some logs of the time it took to run every command during the deployment.

<img width="1043" alt="Screen Shot 2020-12-08 at 6 22 44 PM" src="https://user-images.githubusercontent.com/431299/101543034-6d775180-3982-11eb-999c-aafc526a2a9c.png">
