### PR TITLE
Make git operations noisy

### DIFF
--- a/lib/shipit/task_commands.rb
+++ b/lib/shipit/task_commands.rb
@@ -54,7 +54,6 @@ module Shipit
       [
         git(
           'clone',
-          '--quiet',
           '--local',
           '--origin', 'cache',
           @stack.git_path,


### PR DESCRIPTION
To prevent long-running git operations from being SIGINT-ed.