### PR TITLE
Revert temporary workaround for poor data volume performance

### DIFF
--- a/lib/shipit/stack_commands.rb
+++ b/lib/shipit/stack_commands.rb
@@ -25,7 +25,7 @@ module Shipit
     def fetched?(commit)
       git_dir = File.join(@stack.git_path, '.git')
       if Dir.exist?(git_dir)
-        git('rev-parse', '--verify', "#{commit.sha}^{commit}", env: env, chdir: @stack.git_path)
+        git('rev-parse', '--quiet', '--verify', "#{commit.sha}^{commit}", env: env, chdir: @stack.git_path)
       else
         Command.new('test', '-d', git_dir, env: env, chdir: @stack.deploys_path)
       end

--- a/lib/shipit/task_commands.rb
+++ b/lib/shipit/task_commands.rb
@@ -54,6 +54,7 @@ module Shipit
       [
         git(
           'clone',
+          '--quiet',
           '--local',
           '--origin', 'cache',
           @stack.git_path,

--- a/test/unit/deploy_commands_test.rb
+++ b/test/unit/deploy_commands_test.rb
@@ -63,7 +63,7 @@ module Shipit
       commands = @commands.clone
       assert_equal 2, commands.size
       clone_args = [
-        'git', 'clone',
+        'git', 'clone', '--quiet',
         '--local', '--origin', 'cache',
         @stack.git_path, @deploy.working_directory
       ]


### PR DESCRIPTION
The networking/disk performance incident which necessitated this extra logging to prevent  has since been resolved. We'd prefer to remove to remove the unnecessary logging if we no longer require it.

References
------------

- https://github.com/powerhome/shipit-engine/pull/81
- https://github.com/powerhome/shipit-engine/pull/82