### PR TITLE
Add custom deployment checks

### DIFF
--- a/app/views/shipit/stacks/_banners.html.erb
+++ b/app/views/shipit/stacks/_banners.html.erb
@@ -69,7 +69,8 @@
         <h2 class="banner__title">Continuous Delivery Delayed!</h2>
         <p class="banner__text">
           Continuous Delivery for this stack is currently paused because
-          <%= link_to 'the pre-deploy checks failed', stack_commit_checks_path(stack, sha: stack.next_commit_to_deploy.sha) %>.
+
+          <%= link_to_if stack.deployment_checks_passed?, 'the pre-deploy checks failed', stack_commit_checks_path(stack, sha: stack.next_commit_to_deploy.sha) %>.
           You can either wait for them to pass, or trigger a deploy manually.
         </p>
       </div>

--- a/lib/shipit.rb
+++ b/lib/shipit.rb
@@ -64,7 +64,7 @@ module Shipit
 
   delegate :table_name_prefix, to: :secrets
 
-  attr_accessor :disable_api_authentication, :timeout_exit_codes
+  attr_accessor :disable_api_authentication, :timeout_exit_codes, :deployment_checks
   attr_writer(
     :internal_hook_receivers,
     :preferred_org_emails,

--- a/test/unit/shipit_deployment_checks_test.rb
+++ b/test/unit/shipit_deployment_checks_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Shipit
+  class ShipitDeploymentChecksTest < ActiveSupport::TestCase
+    setup do
+      class FakeDeploymentChecks
+        def self.call(_stack)
+          true
+        end
+      end
+    end
+
+    teardown do
+      Shipit.deployment_checks = nil
+
+      Object.send(:remove_const, :FakeDeploymentChecks) if Object.const_defined?(:FakeDeploymentChecks)
+    end
+
+    test "allows registration of deployment checks" do
+      deployment_checks = FakeDeploymentChecks
+
+      Shipit.deployment_checks = deployment_checks
+
+      assert_equal(
+        deployment_checks,
+        Shipit.deployment_checks
+      )
+    end
+
+    test "allows deployments and continuous delivery when checks are not present" do
+      stack = shipit_stacks(:review_stack)
+      stack.update(continuous_deployment: true)
+
+      Shipit.deployment_checks = nil
+
+      assert stack.deployable?
+
+      stack.trigger_continuous_delivery
+
+      refute stack.continuous_delivery_delayed?
+    end
+
+    test "allows deployments and continuous delivery when checks pass" do
+      stack = shipit_stacks(:review_stack)
+      stack.update(continuous_deployment: true)
+
+      Shipit.deployment_checks = FakeDeploymentChecks
+
+      assert stack.deployable?
+
+      stack.trigger_continuous_delivery
+
+      refute stack.continuous_delivery_delayed?
+    end
+
+    test "prevents deployments and delays continuous delivery when checks fail" do
+      class FakeDeploymentChecks
+        def self.call(_stack)
+          false
+        end
+      end
+
+      stack = shipit_stacks(:review_stack)
+      stack.update(continuous_deployment: true)
+
+      Shipit.deployment_checks = FakeDeploymentChecks
+
+      refute stack.deployable?
+
+      stack.trigger_continuous_delivery
+
+      assert stack.continuous_delivery_delayed?
+    end
+  end
+end


### PR DESCRIPTION
Currently, Shipit has no way of allowing custom checks to determine the deployable state of a particular Stack in order to respond to events which may affect a multitude of Stacks by some other dimension - such as site co-location in the event of a site outage - a host system may want the ability to provide checks which don't necessarily make sense on each stack. This change allows a "custom check" class to be passed in that prevents deployments and delays continuous delivery for a Stack if the checks do not pass.